### PR TITLE
Get-GOItems now returns objects instead of raw xml

### DIFF
--- a/source/private/Convert-EasitXMLToPsObject.ps1
+++ b/source/private/Convert-EasitXMLToPsObject.ps1
@@ -18,7 +18,11 @@ function Convert-EasitXMLToPsObject {
             $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfItems" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfItems)"
             foreach ($column in $Response.Envelope.Body.GetItemsResponse.Columns.GetEnumerator()) {
                 Write-Verbose "Adding property $($column.InnerText) as Noteproperty to object"
-                $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null
+                try {
+                    $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
+                } catch [System.InvalidOperationException] {
+                    Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
+                }
             }
             foreach ($item in $Response.Envelope.Body.GetItemsResponse.Items.GetEnumerator()) {
                 foreach ($itemProperty in $item.GetEnumerator()) {

--- a/source/private/New-XMLforEasit.ps1
+++ b/source/private/New-XMLforEasit.ps1
@@ -198,13 +198,20 @@ function New-XMLforEasit {
         ## Solution provided by Dennis Zakariasson <dennis.zakariasson@regionuppsala.se> thru issue 5
         if ($ColumnFilter) {
             Write-Verbose "Creating xml element for Column filter"
-            foreach ($filter in $ColumnFilter) {
+            $Filters = $ColumnFilter -split ' '
+            Write-Verbose "Filters = $Filters"
+            Write-Verbose "Number of filters = $($Filters.Count)"
+            foreach ($filter in $Filters) {
                 try {
-                    $ColumnFilterValues = $filter -replace ', ', ',' -split ','
+                    Write-Verbose "filter = $filter"
+                    $ColumnFilterValues = $filter -split ','
                     $envelopeColumnFilter = $payload.CreateElement('sch:ColumnFilter',"$xmlnsSch")
+                    Write-Verbose "columnName = $($ColumnFilterValues[0])"
                     $envelopeColumnFilter.SetAttribute("columnName","$($ColumnFilterValues[0])")
                     $envelopeColumnFilter.SetAttribute("comparator","$($ColumnFilterValues[1])")
+                    Write-Verbose "comparator = $($ColumnFilterValues[1])"
                     $envelopeColumnFilter.InnerText = "$($ColumnFilterValues[2])"
+                    Write-Verbose "InnerText = $($ColumnFilterValues[2])"
                     $schGetItemsRequest.AppendChild($envelopeColumnFilter) | Out-Null
                 } catch {
                     Write-Error "Failed to create xml element for ColumnFilter"
@@ -229,9 +236,6 @@ function New-XMLforEasit {
             Write-Error "$_"
             break
       }
-    }
-    if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
-        $payload.Save("$HOME\Documents\payload.xml")
     }
     Write-Verbose "Successfully updated property values in SOAP envelope for all parameters with input provided!"
     return $payload


### PR DESCRIPTION
Get-GOItems now returns objects instead of raw xml.
To accomplish this the cmdlet uses helper functions New-XMLforEasit and Convert-EasitXMLToPsObject