### PR TITLE
Implemented Invoke-EasitWebRequest to Get-GOItems

### DIFF
--- a/docs/v2/Get-GOItems.md
+++ b/docs/v2/Get-GOItems.md
@@ -35,19 +35,33 @@ Get-GOItems -url 'http://localhost/test/webservice/' -apikey '4745f62b7371c2aa5c
 ### EXAMPLE 2
 
 ```powershell
+$url = 'http://localhost/test/webservice/'
+$api = '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
 Get-GOItems -url "$url" -apikey "$api" -view 'RequestsProblems' -page 2
 ```
 
 ### EXAMPLE 3
 
 ```powershell
-Get-GOItems -url "$url" -apikey "$api" -view 'RequestServiceRequests' -page 1 -ColumnFilter 'Name,EQUALS,Extern organisation'
+$getGoItemsParams = @{
+      url = 'http://localhost/test/webservice/'
+      api = '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
+      view = 'RequestServiceRequests'
+      ColumnFilter = 'Name,EQUALS,Extern organisation'
+}
+Get-GOItems @getGoItemsParams
 ```
 
 ### EXAMPLE 4
 
 ```powershell
-Get-GOItems -url "$url" -apikey "$api" -view 'RequestIncidents' -sortOrder 'Ascending' -ColumnFilter "Status,IN,Registrerad", "Prioritet,IN,5"
+$getGoItemsParams = @{
+      url = 'http://localhost/test/webservice/'
+      api = '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
+      view = 'RequestIncidents'
+      sortOrder = 'Ascending'
+}
+Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,IN,5"
 ```
 
 ## PARAMETERS
@@ -138,8 +152,8 @@ Accept wildcard characters: False
 
 ### -SSO
 
-Used if system is using SSO with IWA (Active Directory).
-Not needed when using SAML2
+Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2.<br>
+Cmdlet will use the credentials of the current user to send the web request.
 
 ```yaml
 Type: SwitchParameter
@@ -195,7 +209,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### PSObject
+### System.Object
 
 ## NOTES
 

--- a/docs/v2/en-US/EasitGoWebservice-help.xml
+++ b/docs/v2/en-US/EasitGoWebservice-help.xml
@@ -195,7 +195,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SSO</maml:name>
           <maml:Description>
-            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2</maml:para>
+            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -269,7 +269,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SSO</maml:name>
         <maml:Description>
-          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2</maml:para>
+          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -307,7 +307,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
     <command:returnValues>
       <command:returnValue>
         <dev:type>
-          <maml:name>PSObject</maml:name>
+          <maml:name>System.Object</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -332,21 +332,35 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Get-GOItems -url "$url" -apikey "$api" -view 'RequestsProblems' -page 2</dev:code>
+        <dev:code>$url = 'http://localhost/test/webservice/'
+$api = '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
+Get-GOItems -url "$url" -apikey "$api" -view 'RequestsProblems' -page 2</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
-        <dev:code>Get-GOItems -url "$url" -apikey "$api" -view 'RequestServiceRequests' -page 1 -ColumnFilter 'Name,EQUALS,Extern organisation'</dev:code>
+        <dev:code>$getGoItemsParams = @{
+      url = 'http://localhost/test/webservice/'
+      api = '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
+      view = 'RequestServiceRequests'
+      ColumnFilter = 'Name,EQUALS,Extern organisation'
+}
+Get-GOItems @getGoItemsParams</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
-        <dev:code>Get-GOItems -url "$url" -apikey "$api" -view 'RequestIncidents' -sortOrder 'Ascending' -ColumnFilter "Status,IN,Registrerad", "Prioritet,IN,5"</dev:code>
+        <dev:code>$getGoItemsParams = @{
+      url = 'http://localhost/test/webservice/'
+      api = '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
+      view = 'RequestIncidents'
+      sortOrder = 'Ascending'
+}
+Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,IN,5"</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>

--- a/source/public/Get-GOItems.ps1
+++ b/source/public/Get-GOItems.ps1
@@ -28,6 +28,12 @@ function Get-GOItems {
             [string[]] $ColumnFilter,
 
             [parameter(Mandatory = $false)]
+            [switch] $dryRun,
+
+            [parameter(Mandatory = $false)]
+            [switch] $UseBasicParsing,
+
+            [parameter(Mandatory = $false)]
             [switch] $SSO
       )
 
@@ -48,6 +54,13 @@ function Get-GOItems {
                   throw "Invalid comparator '$($FilterValues[1])' in filter $filter! For a list of valid comparators, run command 'Get-Help Get-GoItems -Parameter ColumnFilter'"
             }
       }
+      $xmlParams = @{
+            Get = $true
+            ItemViewIdentifier = "$importViewIdentifier"
+            SortOrder = "$sortOrder"
+            SortField = "$sortField"
+            Page = "$viewPageNumber"
+      }
       if ($ColumnFilter) {
             Write-Verbose "Validating column filter.."
             Write-Verbose "ColumnFilter = $ColumnFilter"
@@ -64,64 +77,70 @@ function Get-GOItems {
                         return
                   }
             }
+            $xmlParams.Add('ColumnFilter',"$ColumnFilter")
       }
       else {
             Write-Verbose "Skipping ColumnFilter as it is null!"
       }
       ## End issue 6
-      Write-Verbose 'Setting authentication header'
-      # basic authentucation
-      $pair = "$($apikey): "
-      $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-      $basicAuthValue = "Basic $encodedCreds"
-      Write-Verbose 'Authentication header set'
-
       Write-Verbose 'Creating payload'
-
-      $payload = New-XMLforEasit -Get -ItemViewIdentifier "$importViewIdentifier" -SortOrder "$sortOrder" -SortField "$sortField" -Page "$viewPageNumber" -ColumnFilter "$ColumnFilter"
-
-      if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
-            Write-Verbose "Saving payload to ${Home}\Documents\payload.xml"
-            $payload.Save("$Home\Documents\payload.xml")
-      }
-      Write-Verbose 'Setting headers'
-      # HTTP headers
-      $headers = @{SOAPAction = ""; Authorization = $basicAuthValue }
-      Write-Verbose 'Headers set'
-
-      # Calling web service
-      Write-Verbose 'Calling web service and using $SOAP as input for Body parameter'
-      if ($SSO) {
-            try {
-                  Write-Verbose 'Using switch SSO. De facto UseDefaultCredentials for Invoke-WebRequest'
-                  $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers -UseDefaultCredentials
-                  Write-Verbose "Successfully connected to and got data from BPS"
-            }
-            catch {
-                  Write-Error "Failed to connect to BPS!"
-                  Write-Error "$_"
-                  return $payload
-            }
-      }
-      else {
-            try {
-                  $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers
-                  Write-Verbose "Successfully connected to and got data from BPS"
-            }
-            catch {
-                  Write-Error "Failed to connect to BPS!"
-                  Write-Error "$_"
-                  return $payload
-            }
-      }
-
-      New-Variable -Name functionout
-      [xml]$functionout = $r.Content
+      
       try {
-            $returnObjects = Convert-EasitXMLToPsObject -Response $functionout
+            $payload = New-XMLforEasit @xmlParams
+      } catch {
+            throw $_
+      }
+      if ($dryRun) {
+            Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it"
+            $i = 1
+            $currentUserProfile = [Environment]::GetEnvironmentVariable("USERPROFILE")
+            $userProfileDesktop = "$currentUserProfile\Desktop"
+            do {
+                  $outputFileName = "payload_$i.xml"
+                  if (Test-Path $userProfileDesktop\$outputFileName) {
+                        $i++
+                        Write-Verbose "$i"
+                  }
+            } until (!(Test-Path $userProfileDesktop\$outputFileName))
+            if (!(Test-Path $userProfileDesktop\$outputFileName)) {
+                  try {
+                        $outputFileName = "payload_$i.xml"
+                        $payload.Save("$userProfileDesktop\$outputFileName")
+                        Write-Verbose "Saved payload to file, will now end!"
+                        break
+                  }
+                  catch {
+                        throw $_
+                  }
+            }
+      }
+      $easitWebRequestParams = @{
+            Uri = "$url"
+            Apikey = "$apikey"
+            Body = $payload
+      }
+      if ($SSO) {
+            Write-Verbose "Adding UseDefaultCredentials to param hash"
+            $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+      }
+      if ($UseBasicParsing) {
+            Write-Verbose "Adding UseBasicParsing to param hash"
+            $easitWebRequestParams.Add('UseBasicParsing',$true)
+      }
+      try {
+            Write-Verbose "Calling Invoke-EasitWebRequest"
+            $r = Invoke-EasitWebRequest @easitWebRequestParams
       }
       catch {
             throw $_
       }
-      $returnObjects
+      try {
+            Write-Verbose "Converting response"
+            $returnObject = Convert-EasitXMLToPsObject -Response $r
+      }
+      catch {
+            throw $_
+      }
+      Write-Verbose "Returning converted response"
+      $returnObject
 }

--- a/source/public/Get-GOItems.ps1
+++ b/source/public/Get-GOItems.ps1
@@ -84,7 +84,7 @@ function Get-GOItems {
       }
       ## End issue 6
       Write-Verbose 'Creating payload'
-      
+
       try {
             $payload = New-XMLforEasit @xmlParams
       } catch {


### PR DESCRIPTION
Implemented Invoke-EasitWebRequest to Get-GOItems.
Added parameters 'UseBasicParsing' and 'dryRun'.
- UseBasicParsing: This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
- dryRun: Enables user to save payload to its desktop instead of sending it.