### PR TITLE
Implemented Invoke-EasitWebRequest to Import-GOAssetItem

### DIFF
--- a/docs/v2/Get-GOItems.md
+++ b/docs/v2/Get-GOItems.md
@@ -9,18 +9,19 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Get data from BPS/GO with web services.
+Get data from Easit BPS / Easit GO with web services.
 
 ## SYNTAX
 
 ```powershell
 Get-GOItems [[-url] <String>] [-apikey] <String> [-importViewIdentifier] <String> [[-sortOrder] <String>]
- [[-sortField] <String>] [[-viewPageNumber] <Int32>] [[-ColumnFilter] <String[]>] [-SSO] [<CommonParameters>]
+ [[-sortField] <String>] [[-viewPageNumber] <Int32>] [[-ColumnFilter] <String[]>] [-dryRun] [-UseBasicParsing]
+ [-SSO] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Connects to BPS/GO Web service with url, apikey and view and returns each item as an objects.<br>
+Connects to Easit BPS / Easit GO web service with url, apikey and view and returns each item as an objects.<br>
 If the view specified to get items from contains two or more fields with the same name, the value from the latest field will be used.<br>
 All returning objects will have these properties requestedPage, totalNumberOfPages and totalNumberOfItems beyond the once provided by the importViewIdentifier.
 
@@ -68,7 +69,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
 
 ### -apikey
 
-API-key for BPS/GO.
+API-key for Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -76,7 +77,7 @@ Parameter Sets: (All)
 Aliases: api
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -94,7 +95,24 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -dryRun
+
+If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO.
+This parameter does not append, rewrite or remove any files from your desktop.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -110,7 +128,7 @@ Parameter Sets: (All)
 Aliases: view
 
 Required: True
-Position: 3
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -119,7 +137,6 @@ Accept wildcard characters: False
 ### -sortField
 
 Field to sort data with.
-Default = Id
 
 ```yaml
 Type: String
@@ -127,7 +144,7 @@ Parameter Sets: (All)
 Aliases: sf
 
 Required: False
-Position: 5
+Position: 4
 Default value: Id
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -136,7 +153,6 @@ Accept wildcard characters: False
 ### -sortOrder
 
 Order in which to sort data, Descending or Ascending.
-Default = Descending
 
 ```yaml
 Type: String
@@ -144,7 +160,7 @@ Parameter Sets: (All)
 Aliases: so
 
 Required: False
-Position: 4
+Position: 3
 Default value: Descending
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -152,7 +168,7 @@ Accept wildcard characters: False
 
 ### -SSO
 
-Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2.<br>
+Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.<br>
 Cmdlet will use the credentials of the current user to send the web request.
 
 ```yaml
@@ -169,7 +185,7 @@ Accept wildcard characters: False
 
 ### -url
 
-Address to BPS/GO webservice.
+URL to Easit BPS / Easit GO web service.
 Default = http://localhost/webservice/
 
 ```yaml
@@ -178,17 +194,31 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: Http://localhost/webservice/
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseBasicParsing
+
+This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -viewPageNumber
 
-Used to get data from specific page in view.
-Each page contains 25 items.
-Default = 1.
+Used to get data from specific page in view. Each page contains 25 items.
 
 ```yaml
 Type: Int32
@@ -196,13 +226,14 @@ Parameter Sets: (All)
 Aliases: page
 
 Required: False
-Position: 6
+Position: 5
 Default value: 1
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -213,7 +244,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Copyright 2019 Easit AB
+Copyright 2021 Easit AB
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -230,4 +261,3 @@ limitations under the License.
 ## RELATED LINKS
 
 [https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Get-GOItems.ps1](https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Get-GOItems.ps1)
-

--- a/docs/v2/Import-GOAssetItem.md
+++ b/docs/v2/Import-GOAssetItem.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Send data to BPS/GO with web services.
+Send data to Easit BPS / Easit GO with web services.
 
 ## SYNTAX
 
@@ -31,39 +31,52 @@ Import-GOAssetItem [-url <String>] -apikey <String> [-ImportHandlerIdentifier <S
  [-Operator <String>] [-IMEINumber <String>] [-MobilePhoneNumber <String>] [-PhoneNumber <String>]
  [-PukCode <String>] [-ModelPrinter <String>] [-IPAdress <String>] [-MacAddress <String>]
  [-NetworkName <String>] [-ModelServer <String>] [-DNSName <String>] [-ServiceBlackout <String>] [-uid <Int32>]
- [-Attachment <String>] [-SSO] [-dryRun] [-ShowDetails] [<CommonParameters>]
+ [-Attachment <String>] [-SSO] [-UseBasicParsing] [-dryRun] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Update and create assets in Easit BPS/GO.
-Returns ID for asset in Easit BPS/GO.
-Specify 'ID' to update an existing asset.
+Update and / or create assets in Easit BPS / Easit GO. Specify 'ID' to update an existing asset.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 
 ```powershell
-Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetGeneral -AssetName "Test" -SerialNumber "SN-467952" -Description "One general asset." -Status "Active" -Verbose -ShowDetails
+Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetGeneral -AssetName "Test" -SerialNumber "SN-467952" -Description "One general asset." -Status "Active"
 ```
 
 ### EXAMPLE 2
 
 ```powershell
-Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ihi CreateAssetServer -AssetStartDate "2018-06-26" -InternalMemory "32" -HardriveSize "500" -Status "Active"
+$url = 'http://localhost/webservice/'
+$apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+Import-GOAssetItem -url "$url" -apikey "$apikey" -ihi 'CreateAssetServer' -AssetStartDate '2018-06-26' -InternalMemory '32' -HardriveSize '500' -Status 'Active'
 ```
 
 ### EXAMPLE 3
 
 ```powershell
-Import-GOAssetItem -url http://localhost/webservice/ -api a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetPC -ID "45" -OperatingSystem "Windows 10" -Status "Inactive"
+$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    api = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateAssetPC' 
+    ID = '45' 
+    OperatingSystem = 'Windows 10'
+    Status = 'Inactive'
+}
+Import-GOAssetItem @importEasitItem
 ```
 
 ### EXAMPLE 4
 
 ```powershell
-Import-GOAssetItem -url $url -apikey $api -ihi $identifier -ID "156" -Status "Inactive"
+$importEasitItem = @{
+    url = "$url"
+    apikey = "$api"
+    ihi = "$identifier"
+}
+Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"
 ```
 
 ## PARAMETERS
@@ -86,7 +99,7 @@ Accept wildcard characters: False
 
 ### -apikey
 
-API-key for BPS/GO.
+API-key for Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -343,8 +356,8 @@ Accept wildcard characters: False
 
 ### -dryRun
 
-If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to BPS/GO.
-This parameter does not append, rewrite or remove any files from your desktop..
+If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO.
+This parameter does not append, rewrite or remove any files from your desktop.
 
 ```yaml
 Type: SwitchParameter
@@ -440,7 +453,7 @@ Accept wildcard characters: False
 
 ### -ID
 
-ID for asset in BPS/GO.
+ID for asset in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -489,7 +502,6 @@ Accept wildcard characters: False
 ### -ImportHandlerIdentifier
 
 ImportHandler to import data with.
-Default = CreateAssetGeneral
 
 ```yaml
 Type: String
@@ -906,8 +918,7 @@ Accept wildcard characters: False
 
 ### -PurchaseDate
 
-Date of purchase of asset.
-Format = yyyy-MM-dd
+Date of purchase of asset. Format = yyyy-MM-dd
 
 ```yaml
 Type: String
@@ -1001,22 +1012,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -ShowDetails
-
-If specified, the response, including ID, will be displayed to host.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SLA
 
 Service level agreement of asset.
@@ -1053,8 +1048,8 @@ Accept wildcard characters: False
 
 ### -SSO
 
-Used if system is using SSO with IWA (Active Directory).
-Not need when using SAML2
+Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.<br>
+Cmdlet will use the credentials of the current user to send the web request.
 
 ```yaml
 Type: SwitchParameter
@@ -1119,7 +1114,6 @@ Accept wildcard characters: False
 ### -uid
 
 Unique ID for object during import.
-Default = 1.
 
 ```yaml
 Type: Int32
@@ -1135,7 +1129,7 @@ Accept wildcard characters: False
 
 ### -url
 
-Address to BPS/GO webservice.
+URL to Easit BPS / Easit GO web service.
 
 ```yaml
 Type: String
@@ -1146,6 +1140,22 @@ Required: False
 Position: Named
 Default value: Http://localhost/webservice/
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseBasicParsing
+
+This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -1199,16 +1209,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
+### System.Object
+
 ## NOTES
 
-Copyright 2019 Easit AB
+Copyright 2021 Easit AB
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/v2/en-US/EasitGoWebservice-help.xml
+++ b/docs/v2/en-US/EasitGoWebservice-help.xml
@@ -99,19 +99,19 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
       <command:verb>Get</command:verb>
       <command:noun>GOItems</command:noun>
       <maml:description>
-        <maml:para>Get data from BPS/GO with web services.</maml:para>
+        <maml:para>Get data from Easit BPS / Easit GO with web services.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Connects to BPS/GO Web service with url, apikey and view and returns each item as an objects.&lt;br&gt; If the view specified to get items from contains two or more fields with the same name, the value from the latest field will be used.&lt;br&gt; All returning objects will have these properties requestedPage, totalNumberOfPages and totalNumberOfItems beyond the once provided by the importViewIdentifier.</maml:para>
+      <maml:para>Connects to Easit BPS / Easit GO web service with url, apikey and view and returns each item as an objects.&lt;br&gt; If the view specified to get items from contains two or more fields with the same name, the value from the latest field will be used.&lt;br&gt; All returning objects will have these properties requestedPage, totalNumberOfPages and totalNumberOfItems beyond the once provided by the importViewIdentifier.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-GOItems</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
           <maml:name>url</maml:name>
           <maml:Description>
-            <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+            <maml:para>URL to Easit BPS / Easit GO web service. Default = http://localhost/webservice/</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -120,10 +120,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           </dev:type>
           <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="api">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="api">
           <maml:name>apikey</maml:name>
           <maml:Description>
-            <maml:para>API-key for BPS/GO.</maml:para>
+            <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -132,7 +132,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="view">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="view">
           <maml:name>importViewIdentifier</maml:name>
           <maml:Description>
             <maml:para>View to get data from.</maml:para>
@@ -144,10 +144,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="so">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="so">
           <maml:name>sortOrder</maml:name>
           <maml:Description>
-            <maml:para>Order in which to sort data, Descending or Ascending. Default = Descending</maml:para>
+            <maml:para>Order in which to sort data, Descending or Ascending.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -156,10 +156,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           </dev:type>
           <dev:defaultValue>Descending</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="sf">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="sf">
           <maml:name>sortField</maml:name>
           <maml:Description>
-            <maml:para>Field to sort data with. Default = Id</maml:para>
+            <maml:para>Field to sort data with.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -168,10 +168,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           </dev:type>
           <dev:defaultValue>Id</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="page">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="page">
           <maml:name>viewPageNumber</maml:name>
           <maml:Description>
-            <maml:para>Used to get data from specific page in view. Each page contains 25 items. Default = 1.</maml:para>
+            <maml:para>Used to get data from specific page in view. Each page contains 25 items.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -180,7 +180,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           </dev:type>
           <dev:defaultValue>1</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="none">
           <maml:name>ColumnFilter</maml:name>
           <maml:Description>
             <maml:para>Used to filter data.&lt;br&gt; Example: ColumnName,comparator,value&lt;br&gt; Valid comparator: EQUALS, NOT_EQUALS, IN, NOT_IN, GREATER_THAN, GREATER_THAN_OR_EQUALS, LESS_THAN, LESS_THAN_OR_EQUALS, LIKE, NOT_LIKE</maml:para>
@@ -193,9 +193,31 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>dryRun</maml:name>
+          <maml:Description>
+            <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SSO</maml:name>
           <maml:Description>
-            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
+            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseBasicParsing</maml:name>
+          <maml:Description>
+            <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -206,10 +228,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="api">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="api">
         <maml:name>apikey</maml:name>
         <maml:Description>
-          <maml:para>API-key for BPS/GO.</maml:para>
+          <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -218,7 +240,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="none">
         <maml:name>ColumnFilter</maml:name>
         <maml:Description>
           <maml:para>Used to filter data.&lt;br&gt; Example: ColumnName,comparator,value&lt;br&gt; Valid comparator: EQUALS, NOT_EQUALS, IN, NOT_IN, GREATER_THAN, GREATER_THAN_OR_EQUALS, LESS_THAN, LESS_THAN_OR_EQUALS, LIKE, NOT_LIKE</maml:para>
@@ -230,7 +252,19 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="view">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>dryRun</maml:name>
+        <maml:Description>
+          <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="view">
         <maml:name>importViewIdentifier</maml:name>
         <maml:Description>
           <maml:para>View to get data from.</maml:para>
@@ -242,10 +276,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="sf">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="sf">
         <maml:name>sortField</maml:name>
         <maml:Description>
-          <maml:para>Field to sort data with. Default = Id</maml:para>
+          <maml:para>Field to sort data with.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -254,10 +288,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         </dev:type>
         <dev:defaultValue>Id</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="so">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="so">
         <maml:name>sortOrder</maml:name>
         <maml:Description>
-          <maml:para>Order in which to sort data, Descending or Ascending. Default = Descending</maml:para>
+          <maml:para>Order in which to sort data, Descending or Ascending.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -269,7 +303,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SSO</maml:name>
         <maml:Description>
-          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
+          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -278,10 +312,10 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>url</maml:name>
         <maml:Description>
-          <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+          <maml:para>URL to Easit BPS / Easit GO web service. Default = http://localhost/webservice/</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -290,10 +324,22 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
         </dev:type>
         <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="page">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseBasicParsing</maml:name>
+        <maml:Description>
+          <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="page">
         <maml:name>viewPageNumber</maml:name>
         <maml:Description>
-          <maml:para>Used to get data from specific page in view. Each page contains 25 items. Default = 1.</maml:para>
+          <maml:para>Used to get data from specific page in view. Each page contains 25 items.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -316,7 +362,7 @@ PS C:\&gt; Convert-EasitXMLToPsObject -Response $functionout</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Copyright 2019 Easit AB</maml:para>
+        <maml:para>Copyright 2021 Easit AB</maml:para>
         <maml:para>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</maml:para>
         <maml:para>      http://www.apache.org/licenses/LICENSE-2.0</maml:para>
         <maml:para>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</maml:para>
@@ -383,11 +429,11 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:verb>Import</command:verb>
       <command:noun>GOAssetItem</command:noun>
       <maml:description>
-        <maml:para>Send data to BPS/GO with web services.</maml:para>
+        <maml:para>Send data to Easit BPS / Easit GO with web services.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Update and create assets in Easit BPS/GO. Returns ID for asset in Easit BPS/GO. Specify 'ID' to update an existing asset.</maml:para>
+      <maml:para>Update and / or create assets in Easit BPS / Easit GO. Specify 'ID' to update an existing asset.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -407,7 +453,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="api">
           <maml:name>apikey</maml:name>
           <maml:Description>
-            <maml:para>API-key for BPS/GO.</maml:para>
+            <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -599,7 +645,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>dryRun</maml:name>
           <maml:Description>
-            <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to BPS/GO. This parameter does not append, rewrite or remove any files from your desktop..</maml:para>
+            <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -670,7 +716,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ID</maml:name>
           <maml:Description>
-            <maml:para>ID for asset in BPS/GO.</maml:para>
+            <maml:para>ID for asset in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -706,7 +752,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ihi">
           <maml:name>ImportHandlerIdentifier</maml:name>
           <maml:Description>
-            <maml:para>ImportHandler to import data with. Default = CreateAssetGeneral</maml:para>
+            <maml:para>ImportHandler to import data with.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1087,17 +1133,6 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>ShowDetails</maml:name>
-          <maml:Description>
-            <maml:para>If specified, the response, including ID, will be displayed to host.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>SLA</maml:name>
           <maml:Description>
@@ -1125,7 +1160,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SSO</maml:name>
           <maml:Description>
-            <maml:para>Used if system is using SSO with IWA (Active Directory). Not need when using SAML2</maml:para>
+            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1172,7 +1207,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>uid</maml:name>
           <maml:Description>
-            <maml:para>Unique ID for object during import. Default = 1.</maml:para>
+            <maml:para>Unique ID for object during import.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -1184,7 +1219,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="uri">
           <maml:name>url</maml:name>
           <maml:Description>
-            <maml:para>Address to BPS/GO webservice.</maml:para>
+            <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1192,6 +1227,17 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
             <maml:uri />
           </dev:type>
           <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseBasicParsing</maml:name>
+          <maml:Description>
+            <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>UserLogin</maml:name>
@@ -1247,7 +1293,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="api">
         <maml:name>apikey</maml:name>
         <maml:Description>
-          <maml:para>API-key for BPS/GO.</maml:para>
+          <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1439,7 +1485,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>dryRun</maml:name>
         <maml:Description>
-          <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to BPS/GO. This parameter does not append, rewrite or remove any files from your desktop..</maml:para>
+          <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1511,7 +1557,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ID</maml:name>
         <maml:Description>
-          <maml:para>ID for asset in BPS/GO.</maml:para>
+          <maml:para>ID for asset in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -1547,7 +1593,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ihi">
         <maml:name>ImportHandlerIdentifier</maml:name>
         <maml:Description>
-          <maml:para>ImportHandler to import data with. Default = CreateAssetGeneral</maml:para>
+          <maml:para>ImportHandler to import data with.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1928,18 +1974,6 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>ShowDetails</maml:name>
-        <maml:Description>
-          <maml:para>If specified, the response, including ID, will be displayed to host.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>SLA</maml:name>
         <maml:Description>
@@ -1967,7 +2001,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SSO</maml:name>
         <maml:Description>
-          <maml:para>Used if system is using SSO with IWA (Active Directory). Not need when using SAML2</maml:para>
+          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2015,7 +2049,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>uid</maml:name>
         <maml:Description>
-          <maml:para>Unique ID for object during import. Default = 1.</maml:para>
+          <maml:para>Unique ID for object during import.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -2027,7 +2061,7 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="uri">
         <maml:name>url</maml:name>
         <maml:Description>
-          <maml:para>Address to BPS/GO webservice.</maml:para>
+          <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2035,6 +2069,18 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
           <maml:uri />
         </dev:type>
         <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseBasicParsing</maml:name>
+        <maml:Description>
+          <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>UserLogin</maml:name>
@@ -2074,10 +2120,19 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
-    <command:returnValues />
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Copyright 2019 Easit AB</maml:para>
+        <maml:para>Copyright 2021 Easit AB</maml:para>
         <maml:para>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</maml:para>
         <maml:para>    http://www.apache.org/licenses/LICENSE-2.0</maml:para>
         <maml:para>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</maml:para>
@@ -2086,28 +2141,43 @@ Get-GOItems @getGoItemsParams -ColumnFilter "Status,IN,Registrerad", "Prioritet,
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
-        <dev:code>Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetGeneral -AssetName "Test" -SerialNumber "SN-467952" -Description "One general asset." -Status "Active" -Verbose -ShowDetails</dev:code>
+        <dev:code>Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetGeneral -AssetName "Test" -SerialNumber "SN-467952" -Description "One general asset." -Status "Active"</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ihi CreateAssetServer -AssetStartDate "2018-06-26" -InternalMemory "32" -HardriveSize "500" -Status "Active"</dev:code>
+        <dev:code>$url = 'http://localhost/webservice/'
+$apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+Import-GOAssetItem -url "$url" -apikey "$apikey" -ihi 'CreateAssetServer' -AssetStartDate '2018-06-26' -InternalMemory '32' -HardriveSize '500' -Status 'Active'</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
-        <dev:code>Import-GOAssetItem -url http://localhost/webservice/ -api a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetPC -ID "45" -OperatingSystem "Windows 10" -Status "Inactive"</dev:code>
+        <dev:code>$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    api = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateAssetPC' 
+    ID = '45' 
+    OperatingSystem = 'Windows 10'
+    Status = 'Inactive'
+}
+Import-GOAssetItem @importEasitItem</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
-        <dev:code>Import-GOAssetItem -url $url -apikey $api -ihi $identifier -ID "156" -Status "Inactive"</dev:code>
+        <dev:code>$importEasitItem = @{
+    url = "$url"
+    apikey = "$api"
+    ihi = "$identifier"
+}
+Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>

--- a/source/public/Import-GOAssetItem.ps1
+++ b/source/public/Import-GOAssetItem.ps1
@@ -1,179 +1,4 @@
 function Import-GOAssetItem {
-      <#
-      .SYNOPSIS
-            Send data to BPS/GO with web services.
-      .DESCRIPTION
-            Update and create assets in Easit BPS/GO. Returns ID for asset in Easit BPS/GO.
-            Specify 'ID' to update an existing asset.
-
-      .NOTES
-            Copyright 2019 Easit AB
-
-            Licensed under the Apache License, Version 2.0 (the "License");
-            you may not use this file except in compliance with the License.
-            You may obtain a copy of the License at
-
-                http://www.apache.org/licenses/LICENSE-2.0
-
-            Unless required by applicable law or agreed to in writing, software
-            distributed under the License is distributed on an "AS IS" BASIS,
-            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            See the License for the specific language governing permissions and
-            limitations under the License.
-
-      .LINK
-            https://github.com/easitab/EasitGoWebservice/blob/master/EasitGoWebservice/Import-GOAssetItem.ps1
-
-      .EXAMPLE
-            Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetGeneral -AssetName "Test" -SerialNumber "SN-467952" -Description "One general asset." -Status "Active" -Verbose -ShowDetails
-      .EXAMPLE
-            Import-GOAssetItem -url http://localhost/webservice/ -apikey a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ihi CreateAssetServer -AssetStartDate "2018-06-26" -InternalMemory "32" -HardriveSize "500" -Status "Active"
-      .EXAMPLE
-            Import-GOAssetItem -url http://localhost/webservice/ -api a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618 -ImportHandlerIdentifier CreateAssetPC -ID "45" -OperatingSystem "Windows 10" -Status "Inactive"
-      .EXAMPLE
-            Import-GOAssetItem -url $url -apikey $api -ihi $identifier -ID "156" -Status "Inactive"
-      .PARAMETER url
-            Address to BPS/GO webservice. Default = http://localhost/webservice/
-      .PARAMETER apikey
-            API-key for BPS/GO.
-      .PARAMETER ImportHandlerIdentifier
-            ImportHandler to import data with. Default = CreateAssetGeneral
-      .PARAMETER ID
-            ID for asset in BPS/GO.
-      .PARAMETER UID
-            Unique ID for object during import. Default = 1.
-      .PARAMETER AssetType
-            Type of asset.
-      .PARAMETER AssetInvoicingPeriod
-            Invoicing period for asset.
-      .PARAMETER AssetSupplierOrganizationID
-            ID of organization to be set as supplier of asset.
-      .PARAMETER Impact
-            Impact of asset.
-      .PARAMETER Manufacturer
-            Manufacturer of asset.
-      .PARAMETER OwnerContactID
-            ID of contact to be set as owner of asset.
-      .PARAMETER OwnerOrganizationID
-            ID of organization to be set as owner of asset.
-      .PARAMETER PriceListConnectionID
-            ID of price list to connect with asset.
-      .PARAMETER Status
-            Status for asset.
-      .PARAMETER CityLocation
-            Location (City) of asset.
-      .PARAMETER HouseLocation
-            Location (House) of asset.
-      .PARAMETER FinLifteTime
-            Financial lifte time of asset.
-      .PARAMETER LifeCycle
-            Life cycle of asset.
-      .PARAMETER ActivityDebit
-            Activity debit for asset.
-      .PARAMETER AssetName
-            Name of asset.
-      .PARAMETER AssetStartDate
-            Contract start date for asset. Format = yyyy-MM-dd
-      .PARAMETER BarCode
-            Bar code for asset.
-      .PARAMETER CIReference
-            Reference ID for asset.
-      .PARAMETER Description
-            Description of asset.
-      .PARAMETER FinancialNotes
-            Financial notes for asset.
-      .PARAMETER LastInventoryDate
-            Last inventory date of asset. Format = yyyy-MM-dd
-      .PARAMETER ObjectDebit
-            Object debit for asset.
-      .PARAMETER ProjectDebit
-            Project debit for asset.
-      .PARAMETER PurchaseDate
-            Date of purchase of asset. Format = yyyy-MM-dd
-      .PARAMETER PurchaseOrderNumber
-            Purchase order number of asset.
-      .PARAMETER PurchaseValueCurrency
-            Purchase value of asset.
-      .PARAMETER RoomLocation
-            Location (Room) of asset.
-      .PARAMETER SerialNumber
-            Serial number for asset.
-      .PARAMETER SupplierInvoiceId
-            ID of invoice from supplier.
-      .PARAMETER TheftId
-            Theft ID for asset.
-      .PARAMETER WarrantyExpireDate
-            Date for when warranty of asset expires. Format = yyyy-MM-dd
-      .PARAMETER ModelMonitor
-            Model of monitor.
-      .PARAMETER MonitorType
-            Type of monitor.
-      .PARAMETER MonitorSize
-            Size of monitor.
-      .PARAMETER MonitorResolution
-            Resolution of monitor.
-      .PARAMETER ConectionType_Monitor
-            Conection type of monitor.
-      .PARAMETER OperatingSystem
-            Operating system for asset.
-      .PARAMETER Equipment
-            Equipment of asset.
-      .PARAMETER ModelPC
-            Model of PC/Computer.
-      .PARAMETER ComputerType
-            Type of PC/Computer.
-      .PARAMETER HardriveSize
-            Hardrive size of asset.
-      .PARAMETER InternalMemory
-            Internal memory of asset.
-      .PARAMETER ProcessorSpeed
-            Processor speed of asset.
-      .PARAMETER SLA
-            Service level agreement of asset. Valid values = true / false.
-      .PARAMETER SLAExpiredate
-            Expire date for SLA of asset. Format: yyyy-MM-dd
-      .PARAMETER UserLogin
-            Username of person using asset.
-      .PARAMETER UserPassword
-            Password for person using asset.
-      .PARAMETER AssetPhoneModel
-            Model of phone.
-      .PARAMETER AssetPhoneType
-            Type of phone.
-      .PARAMETER Operator
-            Operator for phone.
-      .PARAMETER IMEINumber
-            IMEI number of phone.
-      .PARAMETER MobilePhoneNumber
-            Mobile phone number.
-      .PARAMETER PhoneNumber
-            Phone number.
-      .PARAMETER PukCode
-            PUK code for phone.
-      .PARAMETER ModelPrinter
-            Model of printer.
-      .PARAMETER IPAdress
-            IP address to printer.
-      .PARAMETER MacAddress
-            Printer mac address.
-      .PARAMETER NetworkName
-            Printer network name.
-      .PARAMETER ModelServer
-            Model of server.
-      .PARAMETER DNSName
-            Server DNS name.
-      .PARAMETER ServiceBlackout
-            Notes about when service is undergoing maintenance.
-      .PARAMETER Attachment
-            Full path to file to be included in payload.
-      .PARAMETER SSO
-            Used if system is using SSO with IWA (Active Directory). Not need when using SAML2
-      .PARAMETER ShowDetails
-            If specified, the response, including ID, will be displayed to host.
-      .PARAMETER dryRun
-            If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to BPS/GO.
-            This parameter does not append, rewrite or remove any files from your desktop..
-      #>
       [CmdletBinding()]
       param (
             [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
@@ -250,6 +75,13 @@ function Import-GOAssetItem {
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
             [Alias("StartDate")]
+            [ValidateScript({
+                  if ($_ -match '^\d{4}-\d{2}-\d{2}') {
+                        $true
+                  } else {
+                        throw "$_ does not match the format (yyyy-MM-dd) required for this parameter."
+                  }
+            })]
             [string] $AssetStartDate,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
@@ -266,6 +98,13 @@ function Import-GOAssetItem {
             [string] $FinancialNotes,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
+            [ValidateScript({
+                  if ($_ -match '^\d{4}-\d{2}-\d{2}') {
+                        $true
+                  } else {
+                        throw "$_ does not match the format (yyyy-MM-dd) required for this parameter."
+                  }
+            })]
             [string] $LastInventoryDate,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
@@ -275,6 +114,13 @@ function Import-GOAssetItem {
             [string] $ProjectDebit,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
+            [ValidateScript({
+                  if ($_ -match '^\d{4}-\d{2}-\d{2}') {
+                        $true
+                  } else {
+                        throw "$_ does not match the format (yyyy-MM-dd) required for this parameter."
+                  }
+            })]
             [string] $PurchaseDate,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
@@ -296,6 +142,13 @@ function Import-GOAssetItem {
             [string] $TheftId,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
+            [ValidateScript({
+                  if ($_ -match '^\d{4}-\d{2}-\d{2}') {
+                        $true
+                  } else {
+                        throw "$_ does not match the format (yyyy-MM-dd) required for this parameter."
+                  }
+            })]
             [string] $WarrantyExpireDate,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
@@ -339,6 +192,13 @@ function Import-GOAssetItem {
             [string] $SLA,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
+            [ValidateScript({
+                  if ($_ -match '^\d{4}-\d{2}-\d{2}') {
+                        $true
+                  } else {
+                        throw "$_ does not match the format (yyyy-MM-dd) required for this parameter."
+                  }
+            })]
             [string] $SLAExpiredate,
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
@@ -404,10 +264,10 @@ function Import-GOAssetItem {
             [switch] $SSO,
 
             [parameter(Mandatory = $false)]
-            [switch] $dryRun,
+            [switch] $UseBasicParsing,
 
             [parameter(Mandatory = $false)]
-            [switch] $ShowDetails
+            [switch] $dryRun
       )
       begin {
             Write-Verbose "$($MyInvocation.MyCommand) initialized"
@@ -454,18 +314,20 @@ function Import-GOAssetItem {
                   Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it to BPS"
                   $i = 1
                   $currentUserProfile = [Environment]::GetEnvironmentVariable("USERPROFILE")
-                  $userProfileDesktop = "$currentUserProfile\Desktop"
+                  $userProfileDesktop = Join-Path -Path $currentUserProfile -ChildPath 'Desktop'
                   do {
                         $outputFileName = "payload_$i.xml"
-                        if (Test-Path $userProfileDesktop\$outputFileName) {
+                        $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                        if (Test-Path $payloadFile) {
                               $i++
                               Write-Information "$i"
                         }
-                  } until (!(Test-Path $userProfileDesktop\$outputFileName))
-                  if (!(Test-Path $userProfileDesktop\$outputFileName)) {
+                  } until (!(Test-Path $payloadFile))
+                  if (!(Test-Path $payloadFile)) {
                         try {
                               $outputFileName = "payload_$i.xml"
-                              $payload.Save("$userProfileDesktop\$outputFileName")
+                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                              $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
                         }
@@ -476,55 +338,35 @@ function Import-GOAssetItem {
                         }
                   }
             }
-
-            Write-Verbose "Creating header for web request!"
+            $easitWebRequestParams = @{
+                  Uri = "$url"
+                  Apikey = "$apikey"
+                  Body = $payload
+            }
+            if ($SSO) {
+                  Write-Verbose "Adding UseDefaultCredentials to param hash"
+                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+            }
+            if ($UseBasicParsing) {
+                  Write-Verbose "Adding UseBasicParsing to param hash"
+                  $easitWebRequestParams.Add('UseBasicParsing',$true)
+            }
             try {
-                  $pair = "$($apikey): "
-                  $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-                  $basicAuthValue = "Basic $encodedCreds"
-                  $headers = @{SOAPAction = ""; Authorization = $basicAuthValue }
-                  Write-Verbose "Header created for web request!"
+                  Write-Verbose "Calling Invoke-EasitWebRequest"
+                  $r = Invoke-EasitWebRequest @easitWebRequestParams
             }
             catch {
-                  Write-Error "Failed to create header!"
-                  Write-Error "$_"
-                  break
+                  throw $_
             }
-            Write-Verbose "Calling web service and using payload as input for Body parameter"
-            if ($SSO) {
-                  try {
-                        Write-Verbose 'Using switch SSO. De facto UseDefaultCredentials for Invoke-WebRequest'
-                        $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers -UseDefaultCredentials
-                        Write-Verbose "Successfully connected to and imported data to BPS"
-                  }
-                  catch {
-                        Write-Error "Failed to connect to BPS!"
-                        Write-Error "$_"
-                        return $payload
-                  }
+            try {
+                  Write-Verbose "Converting response"
+                  $returnObject = Convert-EasitXMLToPsObject -Response $r
             }
-            else {
-                  try {
-                        $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers
-                        Write-Verbose "Successfully connected to and imported data to BPS"
-                  }
-                  catch {
-                        Write-Error "Failed to connect to BPS!"
-                        Write-Error "$_"
-                        return $payload
-                  }
+            catch {
+                  throw $_
             }
-
-            New-Variable -Name functionout
-            [xml]$functionout = $r.Content
-            Write-Verbose 'Casted content of reponse as [xml]$functionout'
-
-            if ($ShowDetails) {
-                  $responseResult = $functionout.Envelope.Body.ImportItemsResponse.ImportItemResult.result
-                  $responseID = $functionout.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues.ReturnValue.InnerXml
-                  Write-Information "Result: $responseResult"
-                  Write-Information "ID for created item: $responseID"
-            }
+            Write-Verbose "Returning converted response"
+            return $returnObject
       }
 
       end {


### PR DESCRIPTION
Implemented Invoke-EasitWebRequest to Import-GOAssetItem.
Added parameter 'UseBasicParsing'.
- UseBasicParsing: This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.