### PR TITLE
Implemented Invoke-EasitWebRequest to Import-GOOrganizationItem

### DIFF
--- a/docs/v2/Import-GOAssetItem.md
+++ b/docs/v2/Import-GOAssetItem.md
@@ -1209,6 +1209,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/docs/v2/Import-GOOrganizationItem.md
+++ b/docs/v2/Import-GOOrganizationItem.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Send data to BPS/GO with web services.
+Send data to Easit BPS / Easit GO with web services.
 
 ## SYNTAX
 
@@ -22,14 +22,12 @@ Import-GOOrganizationItem [-url <String>] -apikey <String> [-ImportHandlerIdenti
  [-Phone <String>] [-PostNummer <String>] [-ResponsibilityDebit <String>] [-UtdelningsAdress <String>]
  [-VisitingAddress <String>] [-VisitingCity <String>] [-VisitingZipCode <String>] [-Webshop <String>]
  [-Website <String>] [-AccountManager <String>] [-ServiceManager <String>] [-uid <Int32>]
- [-Attachment <String>] [-SSO] [-dryRun] [-ShowDetails] [<CommonParameters>]
+ [-Attachment <String>] [-SSO] [-UseBasicParsing] [-dryRun] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Update and create organization in Easit BPS/GO.
-Returns ID for item in Easit BPS/GO.
-Specify 'ID' to update an existing organization.
+Update and / or create organizations in Easit BPS / Easit GO. Specify 'ID' to update an existing asset.
 
 ## EXAMPLES
 
@@ -46,7 +44,9 @@ Import-GOOrganizationItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f
 Creates a new organization with *Name* as 'Stuff and IT', *CustomerNumber* as '4678524' and *BusinessDebit* as '1684'. It will set a existing contact with the email 'account.manager@company.com' as *AccountManager*, it will set an existing contract with ID '85' as *MainContract* and an existing user with username 'username123' as *ServiceManager*.
 
 ```powershell
-Import-GOOrganizationItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ihi 'CreateOrganizationExternal' -Name 'Stuff and IT' -CustomerNumber '4678524' -BusinessDebit '1684' -AccountManager 'account.manager@company.com' -MainContractID '85' -ServiceManager 'username123'
+$url = 'http://localhost/webservice/'
+$apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+Import-GOOrganizationItem -url "$url" -apikey "$apikey" -ihi 'CreateOrganizationExternal' -Name 'Stuff and IT' -CustomerNumber '4678524' -BusinessDebit '1684' -AccountManager 'account.manager@company.com' -MainContractID '85' -ServiceManager 'username123'
 ```
 
 ### EXAMPLE 3
@@ -54,7 +54,15 @@ Import-GOOrganizationItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f
 Updates the organization with ID 467 the values from parameters *Category* and *Status*.
 
 ```powershell
-Import-GOOrganizationItem -url 'http://localhost/webservice/' -api 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ImportHandlerIdentifier 'CreateOrganizationSupplier' -ID '467' -Category 'Food' -Status 'Active'
+$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    api = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateOrganizationSupplier'
+    ID = '467'
+    Category = 'Food'
+    Status = 'Active'
+}
+Import-GOOrganizationItem @importEasitItem
 ```
 
 ### EXAMPLE 4
@@ -62,7 +70,13 @@ Import-GOOrganizationItem -url 'http://localhost/webservice/' -api 'a8d5eba7f4da
 Updates the organization with ID 156 to have 'Inactive' as *Status*.
 
 ```powershell
-Import-GOOrganizationItem -url "$url" -apikey "$api" -ihi "$identifier" -ID '156' -Status 'Inactive'
+$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    api = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateOrganizationSupplier'
+    ID = '156'
+}
+Import-GOOrganizationItem @importEasitItem -Status 'Inactive'
 ```
 
 ## PARAMETERS
@@ -101,7 +115,7 @@ Accept wildcard characters: False
 
 ### -apikey
 
-API-key for BPS/GO.
+API-key for Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -261,7 +275,8 @@ Accept wildcard characters: False
 
 ### -dryRun
 
-If specified, payload will be save as payload.xml to your desktop instead of sent to BPS/GO.
+If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO.
+This parameter does not append, rewrite or remove any files from your desktop.
 
 ```yaml
 Type: SwitchParameter
@@ -310,7 +325,7 @@ Accept wildcard characters: False
 
 ### -ID
 
-ID of organization in BPS/GO.
+ID of organization in Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -327,7 +342,6 @@ Accept wildcard characters: False
 ### -ImportHandlerIdentifier
 
 ImportHandler to import data with.
-Default = CreateOrganization_Internal
 
 ```yaml
 Type: String
@@ -501,26 +515,10 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -ShowDetails
-
-If specified, the response, including ID, will be displayed to host.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SSO
 
-Used if system is using SSO with IWA (Active Directory).
-Not need when using SAML2
+Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.<br>
+Cmdlet will use the credentials of the current user to send the web request.
 
 ```yaml
 Type: SwitchParameter
@@ -568,8 +566,7 @@ Accept wildcard characters: False
 
 ### -url
 
-Address to BPS/GO webservice.
-Default = http://localhost/webservice/
+URL to Easit BPS / Easit GO web service.
 
 ```yaml
 Type: String
@@ -580,6 +577,22 @@ Required: False
 Position: Named
 Default value: Http://localhost/webservice/
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseBasicParsing
+
+This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -687,9 +700,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Object
+
 ## NOTES
 
-Copyright 2019 Easit AB
+Copyright 2021 Easit AB
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -706,4 +721,3 @@ limitations under the License.
 ## RELATED LINKS
 
 [https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Import-GOOrganizationItem.ps1](https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Import-GOOrganizationItem.ps1)
-

--- a/docs/v2/en-US/EasitGoWebservice-help.xml
+++ b/docs/v2/en-US/EasitGoWebservice-help.xml
@@ -3037,11 +3037,11 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       <command:verb>Import</command:verb>
       <command:noun>GOOrganizationItem</command:noun>
       <maml:description>
-        <maml:para>Send data to BPS/GO with web services.</maml:para>
+        <maml:para>Send data to Easit BPS / Easit GO with web services.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Update and create organization in Easit BPS/GO. Returns ID for item in Easit BPS/GO. Specify 'ID' to update an existing organization.</maml:para>
+      <maml:para>Update and / or create organizations in Easit BPS / Easit GO. Specify 'ID' to update an existing asset.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -3073,7 +3073,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="api">
           <maml:name>apikey</maml:name>
           <maml:Description>
-            <maml:para>API-key for BPS/GO.</maml:para>
+            <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3193,7 +3193,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>dryRun</maml:name>
           <maml:Description>
-            <maml:para>If specified, payload will be save as payload.xml to your desktop instead of sent to BPS/GO.</maml:para>
+            <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3228,7 +3228,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="OrganizationID">
           <maml:name>ID</maml:name>
           <maml:Description>
-            <maml:para>ID of organization in BPS/GO.</maml:para>
+            <maml:para>ID of organization in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3240,7 +3240,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ihi">
           <maml:name>ImportHandlerIdentifier</maml:name>
           <maml:Description>
-            <maml:para>ImportHandler to import data with. Default = CreateOrganization_Internal</maml:para>
+            <maml:para>ImportHandler to import data with.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3370,20 +3370,9 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>ShowDetails</maml:name>
-          <maml:Description>
-            <maml:para>If specified, the response, including ID, will be displayed to host.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SSO</maml:name>
           <maml:Description>
-            <maml:para>Used if system is using SSO with IWA (Active Directory). Not need when using SAML2</maml:para>
+            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3418,7 +3407,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="uri">
           <maml:name>url</maml:name>
           <maml:Description>
-            <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+            <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3426,6 +3415,17 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseBasicParsing</maml:name>
+          <maml:Description>
+            <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>UtdelningsAdress</maml:name>
@@ -3529,7 +3529,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="api">
         <maml:name>apikey</maml:name>
         <maml:Description>
-          <maml:para>API-key for BPS/GO.</maml:para>
+          <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3649,7 +3649,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>dryRun</maml:name>
         <maml:Description>
-          <maml:para>If specified, payload will be save as payload.xml to your desktop instead of sent to BPS/GO.</maml:para>
+          <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3685,7 +3685,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="OrganizationID">
         <maml:name>ID</maml:name>
         <maml:Description>
-          <maml:para>ID of organization in BPS/GO.</maml:para>
+          <maml:para>ID of organization in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3697,7 +3697,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ihi">
         <maml:name>ImportHandlerIdentifier</maml:name>
         <maml:Description>
-          <maml:para>ImportHandler to import data with. Default = CreateOrganization_Internal</maml:para>
+          <maml:para>ImportHandler to import data with.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3827,21 +3827,9 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>ShowDetails</maml:name>
-        <maml:Description>
-          <maml:para>If specified, the response, including ID, will be displayed to host.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SSO</maml:name>
         <maml:Description>
-          <maml:para>Used if system is using SSO with IWA (Active Directory). Not need when using SAML2</maml:para>
+          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3877,7 +3865,7 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="uri">
         <maml:name>url</maml:name>
         <maml:Description>
-          <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+          <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3885,6 +3873,18 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseBasicParsing</maml:name>
+        <maml:Description>
+          <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>UtdelningsAdress</maml:name>
@@ -3960,10 +3960,19 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
-    <command:returnValues />
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Copyright 2019 Easit AB</maml:para>
+        <maml:para>Copyright 2021 Easit AB</maml:para>
         <maml:para>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</maml:para>
         <maml:para>    http://www.apache.org/licenses/LICENSE-2.0</maml:para>
         <maml:para>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</maml:para>
@@ -3979,21 +3988,37 @@ Import-GOAssetItem @importEasitItem -ID "156" -Status "Inactive"</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Import-GOOrganizationItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ihi 'CreateOrganizationExternal' -Name 'Stuff and IT' -CustomerNumber '4678524' -BusinessDebit '1684' -AccountManager 'account.manager@company.com' -MainContractID '85' -ServiceManager 'username123'</dev:code>
+        <dev:code>$url = 'http://localhost/webservice/'
+$apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+Import-GOOrganizationItem -url "$url" -apikey "$apikey" -ihi 'CreateOrganizationExternal' -Name 'Stuff and IT' -CustomerNumber '4678524' -BusinessDebit '1684' -AccountManager 'account.manager@company.com' -MainContractID '85' -ServiceManager 'username123'</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
-        <dev:code>Import-GOOrganizationItem -url 'http://localhost/webservice/' -api 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ImportHandlerIdentifier 'CreateOrganizationSupplier' -ID '467' -Category 'Food' -Status 'Active'</dev:code>
+        <dev:code>$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    api = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateOrganizationSupplier'
+    ID = '467'
+    Category = 'Food'
+    Status = 'Active'
+}
+Import-GOOrganizationItem @importEasitItem</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
-        <dev:code>Import-GOOrganizationItem -url "$url" -apikey "$api" -ihi "$identifier" -ID '156' -Status 'Inactive'</dev:code>
+        <dev:code>$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    api = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateOrganizationSupplier'
+    ID = '156'
+}
+Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>

--- a/source/public/Import-GOOrganizationItem.ps1
+++ b/source/public/Import-GOOrganizationItem.ps1
@@ -133,11 +133,11 @@ function Import-GOOrganizationItem {
             [parameter(Mandatory=$false)]
             [switch] $SSO,
 
-            [parameter(Mandatory=$false)]
-            [switch] $dryRun,
+            [parameter(Mandatory = $false)]
+            [switch] $UseBasicParsing,
 
             [parameter(Mandatory=$false)]
-            [switch] $ShowDetails
+            [switch] $dryRun
       )
       begin {
             Write-Verbose "$($MyInvocation.MyCommand) initialized"
@@ -177,77 +177,63 @@ function Import-GOOrganizationItem {
             }
             Write-Verbose "Successfully created hashtable of parameter!"
             $payload = New-XMLforEasit -Import -ImportHandlerIdentifier "$ImportHandlerIdentifier" -Params $Params
-
             if ($dryRun) {
                   Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it to BPS"
                   $i = 1
                   $currentUserProfile = [Environment]::GetEnvironmentVariable("USERPROFILE")
-                  $userProfileDesktop = "$currentUserProfile\Desktop"
+                  $userProfileDesktop = Join-Path -Path $currentUserProfile -ChildPath 'Desktop'
                   do {
                         $outputFileName = "payload_$i.xml"
-                        if (Test-Path $userProfileDesktop\$outputFileName) {
+                        $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                        if (Test-Path $payloadFile) {
                               $i++
-                              Write-Verbose "Filename counter: $i"
+                              Write-Information "$i"
                         }
-                  } until (!(Test-Path $userProfileDesktop\$outputFileName))
-                  if (!(Test-Path $userProfileDesktop\$outputFileName)) {
+                  } until (!(Test-Path $payloadFile))
+                  if (!(Test-Path $payloadFile)) {
                         try {
                               $outputFileName = "payload_$i.xml"
-                              $payload.Save("$userProfileDesktop\$outputFileName")
+                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                              $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
-                        } catch {
+                        }
+                        catch {
                               Write-Error "Unable to save payload to file!"
                               Write-Error "$_"
                               break
                         }
                   }
             }
-
-            Write-Verbose "Creating header for web request!"
-            try {
-                  $pair = "$($apikey): "
-                  $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-                  $basicAuthValue = "Basic $encodedCreds"
-                  $headers = @{SOAPAction = ""; Authorization = $basicAuthValue}
-                  Write-Verbose "Header created for web request!"
-            } catch {
-                  Write-Error "Failed to create header!"
-                  Write-Error "$_"
-                  break
+            $easitWebRequestParams = @{
+                  Uri = "$url"
+                  Apikey = "$apikey"
+                  Body = $payload
             }
-            Write-Verbose "Calling web service and using payload as input for Body parameter"
             if ($SSO) {
-                  try {
-                        Write-Verbose 'Using switch SSO. De facto UseDefaultCredentials for Invoke-WebRequest'
-                        $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers -UseDefaultCredentials
-                        Write-Verbose "Successfully connected to and imported data to BPS"
-                  } catch {
-                        Write-Error "Failed to connect to BPS!"
-                        Write-Error "$_"
-                        return $payload
-                  }
-            } else {
-                  try {
-                        $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers
-                        Write-Verbose "Successfully connected to and imported data to BPS"
-                  } catch {
-                        Write-Error "Failed to connect to BPS!"
-                        Write-Error "$_"
-                        return $payload
-                  }
+                  Write-Verbose "Adding UseDefaultCredentials to param hash"
+                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
             }
-
-            New-Variable -Name functionout
-            [xml]$functionout = $r.Content
-            Write-Verbose 'Casted content of reponse as [xml]$functionout'
-
-            if ($ShowDetails) {
-                  $responseResult = $functionout.Envelope.Body.ImportItemsResponse.ImportItemResult.result
-                  $responseID = $functionout.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues.ReturnValue.InnerXml
-                  Write-Information "Result: $responseResult"
-                  Write-Information "ID for created item: $responseID"
+            if ($UseBasicParsing) {
+                  Write-Verbose "Adding UseBasicParsing to param hash"
+                  $easitWebRequestParams.Add('UseBasicParsing',$true)
             }
+            try {
+                  Write-Verbose "Calling Invoke-EasitWebRequest"
+                  $r = Invoke-EasitWebRequest @easitWebRequestParams
+            }
+            catch {
+                  throw $_
+            }
+            try {
+                  Write-Verbose "Converting response"
+                  $returnObject = Convert-EasitXMLToPsObject -Response $r
+            }
+            catch {
+                  throw $_
+            }
+            Write-Verbose "Returning converted response"
+            return $returnObject
       }
       end {
             Write-Verbose "$($MyInvocation.MyCommand) completed"


### PR DESCRIPTION
Implemented Invoke-EasitWebRequest to Import-GOOrganizationItem.
Added parameter 'UseBasicParsing'.
- UseBasicParsing: This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.

Removed parameter 'ShowDetails'.
- ShowDetails: As this cmdlet now returns objects instead of raw XML the object, and its properties, will be outputed to the pipeline (host if available).