### PR TITLE
Implemented Invoke-EasitWebRequest to Import-GORequestItem

### DIFF
--- a/docs/v2/Import-GORequestItem.md
+++ b/docs/v2/Import-GORequestItem.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Send data to BPS/GO with web services.
+Send data to Easit BPS / Easit GO with web services.
 
 ## SYNTAX
 
@@ -21,14 +21,16 @@ Import-GORequestItem [-url <String>] -apikey <String> [-ImportHandlerIdentifier 
  [-AssetsCollectionID <Int32>] [-CausalField <String>] [-ClosingCategory <String>] [-Impact <String>]
  [-Owner <String>] [-ReferenceContactID <Int32>] [-ReferenceOrganizationID <Int32>] [-ServiceID <Int32>]
  [-SLAID <String>] [-Urgency <String>] [-ClassificationID <Int32>] [-KnowledgebaseArticleID <Int32>]
- [-CIID <Int32>] [-uid <Int32>] [-Attachment <String>] [-SSO] [-dryRun] [-ShowDetails] [<CommonParameters>]
+ [-CIID <Int32>] [-uid <Int32>] [-DeliveryInformation <String>] [-ApprovedByID <Int32>] [-Approval <String>]
+ [-ProductsAndServices <String>] [-Message <String>] [-DesiredDelivery <String>] [-PlannedDelivery <String>]
+ [-Workaround <String>] [-ImpactAssessment <String>] [-ResourceRequirement <String>] [-Cause <String>]
+ [-LifeCycle <String>] [-TypeOfChange <String>] [-CategoryOfChange <String>] [-Attachment <String>] [-SSO]
+ [-UseBasicParsing] [-dryRun] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Update and create requests in Easit BPS/GO.
-Returns ID for item in Easit BPS/GO..
-Specify 'ID' to update an existing item.
+Update and / or create requests in Easit BPS / Easit GO. Specify 'ID' to update an existing request.
 
 ## EXAMPLES
 
@@ -41,26 +43,41 @@ Import-GORequestItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa7
 ### EXAMPLE 2
 
 ```powershell
-Import-GORequestItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ImportHandlerIdentifier 'CreateRequestIncident' -Subject 'Testing1' -Description 'Testing1' -ContactID '5' -Status 'Registrerad' -Verbose -ShowDetails
+$url = 'http://localhost/webservice/'
+$apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+Import-GORequestItem -url "$url" -apikey "$apikey" -ImportHandlerIdentifier 'CreateRequestIncident' -Subject 'Testing1' -Description 'Testing1' -ContactID '5' -Status 'Registrerad' -Verbose -ShowDetails
 ```
 
 ### EXAMPLE 3
 
 ```powershell
-Import-GORequestItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ImportHandlerIdentifier 'CreateRequestProblem' -ID '156' -Description 'Testing2. Nytt test!'
+$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateRequestProblem'
+    ID = '156'
+    Description = 'Testing2. Nytt test!'
+}
+Import-GORequestItem @importEasitItem
 ```
 
 ### EXAMPLE 4
 
 ```powershell
-Import-GORequestItem -url "$url" -apikey "$api" -ihi "$identifier" -ID '156' -Description 'Updating description for request 156'
+$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateRequestProblem'
+    ID = '156'
+}
+Import-GORequestItem @importEasitItem -Description 'Updating description for request 156'
 ```
 
 ## PARAMETERS
 
 ### -apikey
 
-API-key for BPS/GO.
+API-key for Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -68,6 +85,39 @@ Parameter Sets: (All)
 Aliases: api
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Approval
+
+Approval for the Service Request.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ApprovedByID
+
+ID of contact responsible for approving.
+Can be found on the contact in Easit BPS / Easit GO.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: ApprovedBy
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -123,6 +173,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -CategoryOfChange
+
+What category of change is it.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -CausalField
 
 Closure cause.
@@ -139,9 +205,26 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Cause
+
+Description of cause.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -CIID
 
-{{ Fill CIID Description }}
+ID of asset to connect to request.
+Can be found on the asset in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -158,7 +241,7 @@ Accept wildcard characters: False
 ### -ClassificationID
 
 ID of classification to connect with request.
-Can be found on the classification in BPS/GO.
+Can be found on the classification in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -190,7 +273,7 @@ Accept wildcard characters: False
 
 ### -ContactID
 
-ID of contact in BPS/GO.
+ID of contact in Easit BPS / Easit GO.
 Can be found on the contact in BPS/GO.
 
 ```yaml
@@ -201,6 +284,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -DeliveryInformation
+
+Information to be used when delivering service request.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -221,9 +320,26 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -DesiredDelivery
+
+Date when delivery is desired.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -dryRun
 
-If specified, payload will be save as payload.xml to your desktop instead of sent to BPS/GO.
+If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO.
+This parameter does not append, rewrite or remove any files from your desktop.
 
 ```yaml
 Type: SwitchParameter
@@ -286,10 +402,25 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -ImpactAssessment
+
+An assessment of the impact for the problem.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -ImportHandlerIdentifier
 
 ImportHandler to import data with.
-Default = CreateRequest
 
 ```yaml
 Type: String
@@ -306,7 +437,7 @@ Accept wildcard characters: False
 ### -KnowledgebaseArticleID
 
 ID of knowledgebase article to connect with request.
-Can be found on the knowledgebase article in BPS/GO.
+Can be found on the knowledgebase article in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -316,6 +447,22 @@ Aliases: KnowledgebaseArticle, KB
 Required: False
 Position: Named
 Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -LifeCycle
+
+What life cycle is the item in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -352,10 +499,26 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Message
+
+Message to the manager.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -OrganizationID
 
 ID for organization to which the contact belongs to.
-Can be found on the organization in BPS/GO.
+Can be found on the organization in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -402,6 +565,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -PlannedDelivery
+
+Date when delivery is planned to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -Priority
 
 Priority for item.
@@ -419,10 +598,26 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -ProductsAndServices
+
+What products and / or services should the request have.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -ReferenceContactID
 
 ID of reference contact.
-Can be found on the contact in BPS/GO.
+Can be found on the contact in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -439,7 +634,7 @@ Accept wildcard characters: False
 ### -ReferenceOrganizationID
 
 ID of reference organization.
-Can be found on the organization in BPS/GO.
+Can be found on the organization in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -453,10 +648,26 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -ResourceRequirement
+
+Requirement for resources.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -ServiceID
 
 ID of article to connect with request.
-Can be found on the article in BPS/GO.
+Can be found on the article in Easit BPS / Easit GO.
 
 ```yaml
 Type: Int32
@@ -470,26 +681,10 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -ShowDetails
-
-If specified, the response, including ID, will be displayed to host.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SLAID
 
 ID of contract to connect with request.
-Can be found on the contract in BPS/GO.
+Can be found on the contract in Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -505,8 +700,8 @@ Accept wildcard characters: False
 
 ### -SSO
 
-Used if system is using SSO with IWA (Active Directory).
-Not need when using SAML2
+Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.<br>
+Cmdlet will use the credentials of the current user to send the web request.
 
 ```yaml
 Type: SwitchParameter
@@ -570,9 +765,25 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -TypeOfChange
+
+What type of change is it.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -uid
 
-{{ Fill uid Description }}
+Unique ID for object during import.
 
 ```yaml
 Type: Int32
@@ -604,8 +815,7 @@ Accept wildcard characters: False
 
 ### -url
 
-Address to BPS/GO webservice.
-Default = http://localhost/webservice/
+URL to Easit BPS / Easit GO web service.
 
 ```yaml
 Type: String
@@ -619,6 +829,38 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -UseBasicParsing
+
+This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Workaround
+
+What workaround is available.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
@@ -627,9 +869,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Object
+
 ## NOTES
 
-Copyright 2019 Easit AB
+Copyright 2021 Easit AB
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -646,4 +890,3 @@ limitations under the License.
 ## RELATED LINKS
 
 [https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Import-GORequestItem.ps1](https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Import-GORequestItem.ps1)
-

--- a/docs/v2/en-US/EasitGoWebservice-help.xml
+++ b/docs/v2/en-US/EasitGoWebservice-help.xml
@@ -4066,11 +4066,11 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:verb>Import</command:verb>
       <command:noun>GORequestItem</command:noun>
       <maml:description>
-        <maml:para>Send data to BPS/GO with web services.</maml:para>
+        <maml:para>Send data to Easit BPS / Easit GO with web services.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Update and create requests in Easit BPS/GO. Returns ID for item in Easit BPS/GO.. Specify 'ID' to update an existing item.</maml:para>
+      <maml:para>Update and / or create requests in Easit BPS / Easit GO. Specify 'ID' to update an existing request.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -4078,11 +4078,35 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="api">
           <maml:name>apikey</maml:name>
           <maml:Description>
-            <maml:para>API-key for BPS/GO.</maml:para>
+            <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Approval</maml:name>
+          <maml:Description>
+            <maml:para>Approval for the Service Request.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ApprovedBy">
+          <maml:name>ApprovedByID</maml:name>
+          <maml:Description>
+            <maml:para>ID of contact responsible for approving. Can be found on the contact in Easit BPS / Easit GO.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -4123,6 +4147,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>CategoryOfChange</maml:name>
+          <maml:Description>
+            <maml:para>What category of change is it.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ClosureCause">
           <maml:name>CausalField</maml:name>
           <maml:Description>
@@ -4135,10 +4171,22 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Cause</maml:name>
+          <maml:Description>
+            <maml:para>Description of cause.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="CI">
           <maml:name>CIID</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill CIID Description }}</maml:para>
+            <maml:para>ID of asset to connect to request. Can be found on the asset in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4150,7 +4198,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Classification">
           <maml:name>ClassificationID</maml:name>
           <maml:Description>
-            <maml:para>ID of classification to connect with request. Can be found on the classification in BPS/GO.</maml:para>
+            <maml:para>ID of classification to connect with request. Can be found on the classification in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4174,7 +4222,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ContactID</maml:name>
           <maml:Description>
-            <maml:para>ID of contact in BPS/GO. Can be found on the contact in BPS/GO.</maml:para>
+            <maml:para>ID of contact in Easit BPS / Easit GO. Can be found on the contact in BPS/GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4182,6 +4230,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DeliveryInformation</maml:name>
+          <maml:Description>
+            <maml:para>Information to be used when delivering service request.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Description</maml:name>
@@ -4195,10 +4255,22 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DesiredDelivery</maml:name>
+          <maml:Description>
+            <maml:para>Date when delivery is desired.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>dryRun</maml:name>
           <maml:Description>
-            <maml:para>If specified, payload will be save as payload.xml to your desktop instead of sent to BPS/GO.</maml:para>
+            <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -4242,10 +4314,22 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ImpactAssessment</maml:name>
+          <maml:Description>
+            <maml:para>An assessment of the impact for the problem.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ihi">
           <maml:name>ImportHandlerIdentifier</maml:name>
           <maml:Description>
-            <maml:para>ImportHandler to import data with. Default = CreateRequest</maml:para>
+            <maml:para>ImportHandler to import data with.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4257,7 +4341,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="KnowledgebaseArticle, KB">
           <maml:name>KnowledgebaseArticleID</maml:name>
           <maml:Description>
-            <maml:para>ID of knowledgebase article to connect with request. Can be found on the knowledgebase article in BPS/GO.</maml:para>
+            <maml:para>ID of knowledgebase article to connect with request. Can be found on the knowledgebase article in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4265,6 +4349,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>LifeCycle</maml:name>
+          <maml:Description>
+            <maml:para>What life cycle is the item in.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Manager</maml:name>
@@ -4291,9 +4387,21 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Message</maml:name>
+          <maml:Description>
+            <maml:para>Message to the manager.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>OrganizationID</maml:name>
           <maml:Description>
-            <maml:para>ID for organization to which the contact belongs to. Can be found on the organization in BPS/GO.</maml:para>
+            <maml:para>ID for organization to which the contact belongs to. Can be found on the organization in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4327,6 +4435,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PlannedDelivery</maml:name>
+          <maml:Description>
+            <maml:para>Date when delivery is planned to.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Priority</maml:name>
           <maml:Description>
             <maml:para>Priority for item. Matches agains existing priorities.</maml:para>
@@ -4339,9 +4459,21 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ProductsAndServices</maml:name>
+          <maml:Description>
+            <maml:para>What products and / or services should the request have.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ReferenceContactID</maml:name>
           <maml:Description>
-            <maml:para>ID of reference contact. Can be found on the contact in BPS/GO.</maml:para>
+            <maml:para>ID of reference contact. Can be found on the contact in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4353,7 +4485,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ReferenceOrganizationID</maml:name>
           <maml:Description>
-            <maml:para>ID of reference organization. Can be found on the organization in BPS/GO.</maml:para>
+            <maml:para>ID of reference organization. Can be found on the organization in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4361,11 +4493,23 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ResourceRequirement</maml:name>
+          <maml:Description>
+            <maml:para>Requirement for resources.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Article">
           <maml:name>ServiceID</maml:name>
           <maml:Description>
-            <maml:para>ID of article to connect with request. Can be found on the article in BPS/GO.</maml:para>
+            <maml:para>ID of article to connect with request. Can be found on the article in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4374,21 +4518,10 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>ShowDetails</maml:name>
-          <maml:Description>
-            <maml:para>If specified, the response, including ID, will be displayed to host.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="SLA">
           <maml:name>SLAID</maml:name>
           <maml:Description>
-            <maml:para>ID of contract to connect with request. Can be found on the contract in BPS/GO.</maml:para>
+            <maml:para>ID of contract to connect with request. Can be found on the contract in Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4400,7 +4533,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SSO</maml:name>
           <maml:Description>
-            <maml:para>Used if system is using SSO with IWA (Active Directory). Not need when using SAML2</maml:para>
+            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -4445,9 +4578,21 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>TypeOfChange</maml:name>
+          <maml:Description>
+            <maml:para>What type of change is it.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>uid</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill uid Description }}</maml:para>
+            <maml:para>Unique ID for object during import.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -4471,7 +4616,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="uri">
           <maml:name>url</maml:name>
           <maml:Description>
-            <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+            <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4480,17 +4625,64 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           </dev:type>
           <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseBasicParsing</maml:name>
+          <maml:Description>
+            <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Workaround</maml:name>
+          <maml:Description>
+            <maml:para>What workaround is available.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="api">
         <maml:name>apikey</maml:name>
         <maml:Description>
-          <maml:para>API-key for BPS/GO.</maml:para>
+          <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Approval</maml:name>
+        <maml:Description>
+          <maml:para>Approval for the Service Request.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ApprovedBy">
+        <maml:name>ApprovedByID</maml:name>
+        <maml:Description>
+          <maml:para>ID of contact responsible for approving. Can be found on the contact in Easit BPS / Easit GO.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4531,6 +4723,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>CategoryOfChange</maml:name>
+        <maml:Description>
+          <maml:para>What category of change is it.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ClosureCause">
         <maml:name>CausalField</maml:name>
         <maml:Description>
@@ -4543,10 +4747,22 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Cause</maml:name>
+        <maml:Description>
+          <maml:para>Description of cause.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="CI">
         <maml:name>CIID</maml:name>
         <maml:Description>
-          <maml:para>{{ Fill CIID Description }}</maml:para>
+          <maml:para>ID of asset to connect to request. Can be found on the asset in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4558,7 +4774,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Classification">
         <maml:name>ClassificationID</maml:name>
         <maml:Description>
-          <maml:para>ID of classification to connect with request. Can be found on the classification in BPS/GO.</maml:para>
+          <maml:para>ID of classification to connect with request. Can be found on the classification in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4582,7 +4798,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ContactID</maml:name>
         <maml:Description>
-          <maml:para>ID of contact in BPS/GO. Can be found on the contact in BPS/GO.</maml:para>
+          <maml:para>ID of contact in Easit BPS / Easit GO. Can be found on the contact in BPS/GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4590,6 +4806,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DeliveryInformation</maml:name>
+        <maml:Description>
+          <maml:para>Information to be used when delivering service request.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>Description</maml:name>
@@ -4603,10 +4831,22 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DesiredDelivery</maml:name>
+        <maml:Description>
+          <maml:para>Date when delivery is desired.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>dryRun</maml:name>
         <maml:Description>
-          <maml:para>If specified, payload will be save as payload.xml to your desktop instead of sent to BPS/GO.</maml:para>
+          <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -4651,10 +4891,22 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ImpactAssessment</maml:name>
+        <maml:Description>
+          <maml:para>An assessment of the impact for the problem.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ihi">
         <maml:name>ImportHandlerIdentifier</maml:name>
         <maml:Description>
-          <maml:para>ImportHandler to import data with. Default = CreateRequest</maml:para>
+          <maml:para>ImportHandler to import data with.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -4666,7 +4918,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="KnowledgebaseArticle, KB">
         <maml:name>KnowledgebaseArticleID</maml:name>
         <maml:Description>
-          <maml:para>ID of knowledgebase article to connect with request. Can be found on the knowledgebase article in BPS/GO.</maml:para>
+          <maml:para>ID of knowledgebase article to connect with request. Can be found on the knowledgebase article in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4674,6 +4926,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>LifeCycle</maml:name>
+        <maml:Description>
+          <maml:para>What life cycle is the item in.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>Manager</maml:name>
@@ -4700,9 +4964,21 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Message</maml:name>
+        <maml:Description>
+          <maml:para>Message to the manager.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>OrganizationID</maml:name>
         <maml:Description>
-          <maml:para>ID for organization to which the contact belongs to. Can be found on the organization in BPS/GO.</maml:para>
+          <maml:para>ID for organization to which the contact belongs to. Can be found on the organization in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4736,6 +5012,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>PlannedDelivery</maml:name>
+        <maml:Description>
+          <maml:para>Date when delivery is planned to.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>Priority</maml:name>
         <maml:Description>
           <maml:para>Priority for item. Matches agains existing priorities.</maml:para>
@@ -4748,9 +5036,21 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ProductsAndServices</maml:name>
+        <maml:Description>
+          <maml:para>What products and / or services should the request have.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ReferenceContactID</maml:name>
         <maml:Description>
-          <maml:para>ID of reference contact. Can be found on the contact in BPS/GO.</maml:para>
+          <maml:para>ID of reference contact. Can be found on the contact in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4762,7 +5062,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ReferenceOrganizationID</maml:name>
         <maml:Description>
-          <maml:para>ID of reference organization. Can be found on the organization in BPS/GO.</maml:para>
+          <maml:para>ID of reference organization. Can be found on the organization in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4770,11 +5070,23 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ResourceRequirement</maml:name>
+        <maml:Description>
+          <maml:para>Requirement for resources.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Article">
         <maml:name>ServiceID</maml:name>
         <maml:Description>
-          <maml:para>ID of article to connect with request. Can be found on the article in BPS/GO.</maml:para>
+          <maml:para>ID of article to connect with request. Can be found on the article in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4783,22 +5095,10 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>ShowDetails</maml:name>
-        <maml:Description>
-          <maml:para>If specified, the response, including ID, will be displayed to host.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="SLA">
         <maml:name>SLAID</maml:name>
         <maml:Description>
-          <maml:para>ID of contract to connect with request. Can be found on the contract in BPS/GO.</maml:para>
+          <maml:para>ID of contract to connect with request. Can be found on the contract in Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -4810,7 +5110,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SSO</maml:name>
         <maml:Description>
-          <maml:para>Used if system is using SSO with IWA (Active Directory). Not need when using SAML2</maml:para>
+          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -4856,9 +5156,21 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>TypeOfChange</maml:name>
+        <maml:Description>
+          <maml:para>What type of change is it.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>uid</maml:name>
         <maml:Description>
-          <maml:para>{{ Fill uid Description }}</maml:para>
+          <maml:para>Unique ID for object during import.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -4882,7 +5194,7 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="uri">
         <maml:name>url</maml:name>
         <maml:Description>
-          <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+          <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -4891,12 +5203,45 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
         </dev:type>
         <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseBasicParsing</maml:name>
+        <maml:Description>
+          <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Workaround</maml:name>
+        <maml:Description>
+          <maml:para>What workaround is available.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
-    <command:returnValues />
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Copyright 2019 Easit AB</maml:para>
+        <maml:para>Copyright 2021 Easit AB</maml:para>
         <maml:para>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</maml:para>
         <maml:para>    http://www.apache.org/licenses/LICENSE-2.0</maml:para>
         <maml:para>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</maml:para>
@@ -4912,21 +5257,36 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Import-GORequestItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ImportHandlerIdentifier 'CreateRequestIncident' -Subject 'Testing1' -Description 'Testing1' -ContactID '5' -Status 'Registrerad' -Verbose -ShowDetails</dev:code>
+        <dev:code>$url = 'http://localhost/webservice/'
+$apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+Import-GORequestItem -url "$url" -apikey "$apikey" -ImportHandlerIdentifier 'CreateRequestIncident' -Subject 'Testing1' -Description 'Testing1' -ContactID '5' -Status 'Registrerad' -Verbose -ShowDetails</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
-        <dev:code>Import-GORequestItem -url 'http://localhost/webservice/' -apikey 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618' -ImportHandlerIdentifier 'CreateRequestProblem' -ID '156' -Description 'Testing2. Nytt test!'</dev:code>
+        <dev:code>$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateRequestProblem'
+    ID = '156'
+    Description = 'Testing2. Nytt test!'
+}
+Import-GORequestItem @importEasitItem</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
-        <dev:code>Import-GORequestItem -url "$url" -apikey "$api" -ihi "$identifier" -ID '156' -Description 'Updating description for request 156'</dev:code>
+        <dev:code>$importEasitItem = @{
+    url = 'http://localhost/webservice/'
+    apikey = 'a8d5eba7f4daa79ea6f1c17c6b453d17df9c27727610b142c70c51bb4eda3618'
+    ImportHandlerIdentifier = 'CreateRequestProblem'
+    ID = '156'
+}
+Import-GORequestItem @importEasitItem -Description 'Updating description for request 156'</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>

--- a/source/public/Import-GORequestItem.ps1
+++ b/source/public/Import-GORequestItem.ps1
@@ -119,7 +119,7 @@ function Import-GORequestItem {
 
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [string] $ProductsAndServices,
-            
+
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [string] $Message,
 
@@ -157,10 +157,10 @@ function Import-GORequestItem {
 
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [string] $LifeCycle,
-            
+
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [string] $TypeOfChange,
-            
+
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [string] $CategoryOfChange,
 
@@ -171,11 +171,11 @@ function Import-GORequestItem {
             [parameter(Mandatory=$false)]
             [switch] $SSO,
 
-            [parameter(Mandatory=$false)]
-            [switch] $dryRun,
+            [parameter(Mandatory = $false)]
+            [switch] $UseBasicParsing,
 
             [parameter(Mandatory=$false)]
-            [switch] $ShowDetails
+            [switch] $dryRun
       )
       begin {
             Write-Verbose "$($MyInvocation.MyCommand) initialized"
@@ -215,77 +215,63 @@ function Import-GORequestItem {
             }
             Write-Verbose "Successfully created hashtable of parameter!"
             $payload = New-XMLforEasit -Import -ImportHandlerIdentifier "$ImportHandlerIdentifier" -Params $Params
-
             if ($dryRun) {
                   Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it to BPS"
                   $i = 1
                   $currentUserProfile = [Environment]::GetEnvironmentVariable("USERPROFILE")
-                  $userProfileDesktop = "$currentUserProfile\Desktop"
+                  $userProfileDesktop = Join-Path -Path $currentUserProfile -ChildPath 'Desktop'
                   do {
                         $outputFileName = "payload_$i.xml"
-                        if (Test-Path $userProfileDesktop\$outputFileName) {
+                        $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                        if (Test-Path $payloadFile) {
                               $i++
-                              Write-Verbose "Filename counter: $i"
+                              Write-Information "$i"
                         }
-                  } until (!(Test-Path $userProfileDesktop\$outputFileName))
-                  if (!(Test-Path $userProfileDesktop\$outputFileName)) {
+                  } until (!(Test-Path $payloadFile))
+                  if (!(Test-Path $payloadFile)) {
                         try {
                               $outputFileName = "payload_$i.xml"
-                              $payload.Save("$userProfileDesktop\$outputFileName")
+                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                              $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
-                        } catch {
+                        }
+                        catch {
                               Write-Error "Unable to save payload to file!"
                               Write-Error "$_"
                               break
                         }
                   }
             }
-
-            Write-Verbose "Creating header for web request!"
-            try {
-                  $pair = "$($apikey): "
-                  $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-                  $basicAuthValue = "Basic $encodedCreds"
-                  $headers = @{SOAPAction = ""; Authorization = $basicAuthValue}
-                  Write-Verbose "Header created for web request!"
-            } catch {
-                  Write-Error "Failed to create header!"
-                  Write-Error "$_"
-                  break
+            $easitWebRequestParams = @{
+                  Uri = "$url"
+                  Apikey = "$apikey"
+                  Body = $payload
             }
-            Write-Verbose "Calling web service and using payload as input for Body parameter"
             if ($SSO) {
-                  try {
-                        Write-Verbose 'Using switch SSO. De facto UseDefaultCredentials for Invoke-WebRequest'
-                        $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers -UseDefaultCredentials
-                        Write-Verbose "Successfully connected to and imported data to BPS"
-                  } catch {
-                        Write-Error "Failed to connect to BPS!"
-                        Write-Error "$_"
-                        return $payload
-                  }
-            } else {
-                  try {
-                        $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers
-                        Write-Verbose "Successfully connected to and imported data to BPS"
-                  } catch {
-                        Write-Error "Failed to connect to BPS!"
-                        Write-Error "$_"
-                        return $payload
-                  }
+                  Write-Verbose "Adding UseDefaultCredentials to param hash"
+                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
             }
-
-            New-Variable -Name functionout
-            [xml]$functionout = $r.Content
-            Write-Verbose 'Casted content of reponse as [xml]$functionout'
-
-            if ($ShowDetails) {
-                  $responseResult = $functionout.Envelope.Body.ImportItemsResponse.ImportItemResult.result
-                  $responseID = $functionout.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues.ReturnValue.InnerXml
-                  Write-Information "Result: $responseResult"
-                  Write-Information "ID for created item: $responseID"
+            if ($UseBasicParsing) {
+                  Write-Verbose "Adding UseBasicParsing to param hash"
+                  $easitWebRequestParams.Add('UseBasicParsing',$true)
             }
+            try {
+                  Write-Verbose "Calling Invoke-EasitWebRequest"
+                  $r = Invoke-EasitWebRequest @easitWebRequestParams
+            }
+            catch {
+                  throw $_
+            }
+            try {
+                  Write-Verbose "Converting response"
+                  $returnObject = Convert-EasitXMLToPsObject -Response $r
+            }
+            catch {
+                  throw $_
+            }
+            Write-Verbose "Returning converted response"
+            return $returnObject
       }
       end {
             Write-Verbose "$($MyInvocation.MyCommand) completed"


### PR DESCRIPTION
Implemented Invoke-EasitWebRequest to Import-GOOrganizationItem.
Added parameter 'UseBasicParsing'.
- UseBasicParsing: This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.

Removed parameter 'ShowDetails'.
- ShowDetails: As this cmdlet now returns objects instead of raw XML the object, and its properties, will be outputed to the pipeline (host if available).