### PR TITLE
Implemented Invoke-EasitWebRequest and Convert-EasitXMLToPsObject to Ping-GOWebService

### DIFF
--- a/docs/v2/Ping-GOWebService.md
+++ b/docs/v2/Ping-GOWebService.md
@@ -8,28 +8,32 @@ schema: 2.0.0
 # Ping-GOWebService
 
 ## SYNOPSIS
-Ping BPS/GO web services.
+
+Ping Easit BPS / Easit GO web services.
 
 ## SYNTAX
 
-```
+```powershell
 Ping-GOWebService [[-url] <String>] [-apikey] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Can be used to check if service is available and correct credentials have been provided..
+
+Can be used to check if service is available and correct credentials have been provided.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
-```
-Ping-GOWebService -url http://localhost/test/webservice/ -apikey 4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375
+
+```powershell
+Ping-GOWebService -url 'http://localhost/test/webservice/' -apikey '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'
 ```
 
 ## PARAMETERS
 
 ### -apikey
-API key for BPS/GO.
+
+API-key for Easit BPS / Easit GO.
 
 ```yaml
 Type: String
@@ -43,9 +47,43 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -dryRun
+
+If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO.
+This parameter does not append, rewrite or remove any files from your desktop.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SSO
+
+Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.<br>
+Cmdlet will use the credentials of the current user to send the web request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -url
-Address to BPS/GO webservice.
-Default = http://localhost/webservice/
+
+URL to Easit BPS / Easit GO web service.
 
 ```yaml
 Type: String
@@ -59,15 +97,35 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -UseBasicParsing
+
+This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
+### System.Object
+
 ## NOTES
-Copyright 2019 Easit AB
+
+Copyright 2021 Easit AB
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -83,5 +141,4 @@ limitations under the License.
 
 ## RELATED LINKS
 
-[https://github.com/easitab/EasitGoWebservice/blob/master/EasitGoWebservice/Ping-GOWebService.ps1](https://github.com/easitab/EasitGoWebservice/blob/master/EasitGoWebservice/Ping-GOWebService.ps1)
-
+[https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Ping-GOWebService.ps1](https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Ping-GOWebService.ps1)

--- a/docs/v2/en-US/EasitGoWebservice-help.xml
+++ b/docs/v2/en-US/EasitGoWebservice-help.xml
@@ -5858,11 +5858,11 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
       <command:verb>Ping</command:verb>
       <command:noun>GOWebService</command:noun>
       <maml:description>
-        <maml:para>Ping BPS/GO web services.</maml:para>
+        <maml:para>Ping Easit BPS / Easit GO web services.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Can be used to check if service is available and correct credentials have been provided..</maml:para>
+      <maml:para>Can be used to check if service is available and correct credentials have been provided.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -5870,7 +5870,7 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
           <maml:name>url</maml:name>
           <maml:Description>
-            <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+            <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -5882,7 +5882,7 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="api">
           <maml:name>apikey</maml:name>
           <maml:Description>
-            <maml:para>API key for BPS/GO.</maml:para>
+            <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -5891,13 +5891,46 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>dryRun</maml:name>
+          <maml:Description>
+            <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SSO</maml:name>
+          <maml:Description>
+            <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseBasicParsing</maml:name>
+          <maml:Description>
+            <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="api">
         <maml:name>apikey</maml:name>
         <maml:Description>
-          <maml:para>API key for BPS/GO.</maml:para>
+          <maml:para>API-key for Easit BPS / Easit GO.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -5906,10 +5939,34 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>dryRun</maml:name>
+        <maml:Description>
+          <maml:para>If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO. This parameter does not append, rewrite or remove any files from your desktop.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>SSO</maml:name>
+        <maml:Description>
+          <maml:para>Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.&lt;br&gt; Cmdlet will use the credentials of the current user to send the web request.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
         <maml:name>url</maml:name>
         <maml:Description>
-          <maml:para>Address to BPS/GO webservice. Default = http://localhost/webservice/</maml:para>
+          <maml:para>URL to Easit BPS / Easit GO web service.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -5918,12 +5975,33 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
         </dev:type>
         <dev:defaultValue>Http://localhost/webservice/</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseBasicParsing</maml:name>
+        <maml:Description>
+          <maml:para>This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
-    <command:returnValues />
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Copyright 2019 Easit AB</maml:para>
+        <maml:para>Copyright 2021 Easit AB</maml:para>
         <maml:para>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at</maml:para>
         <maml:para>    http://www.apache.org/licenses/LICENSE-2.0</maml:para>
         <maml:para>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</maml:para>
@@ -5932,7 +6010,7 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
-        <dev:code>Ping-GOWebService -url http://localhost/test/webservice/ -apikey 4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375</dev:code>
+        <dev:code>Ping-GOWebService -url 'http://localhost/test/webservice/' -apikey '4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375'</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -5944,8 +6022,8 @@ PS C:\&gt; Invoke-EasitWebRequest @easitWebRequestParams</dev:code>
         <maml:uri>https://github.com/easitab/EasitGoWebservice/blob/development/docs/v2/Ping-GOWebService.md</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
-        <maml:linkText>https://github.com/easitab/EasitGoWebservice/blob/master/EasitGoWebservice/Ping-GOWebService.ps1</maml:linkText>
-        <maml:uri>https://github.com/easitab/EasitGoWebservice/blob/master/EasitGoWebservice/Ping-GOWebService.ps1</maml:uri>
+        <maml:linkText>https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Ping-GOWebService.ps1</maml:linkText>
+        <maml:uri>https://github.com/easitab/EasitGoWebservice/blob/development/source/public/Ping-GOWebService.ps1</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/source/public/Get-GOItems.ps1
+++ b/source/public/Get-GOItems.ps1
@@ -91,21 +91,21 @@ function Get-GOItems {
             throw $_
       }
       if ($dryRun) {
-            Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it"
+            Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it to BPS"
             $i = 1
             $currentUserProfile = [Environment]::GetEnvironmentVariable("USERPROFILE")
-            $userProfileDesktop = "$currentUserProfile\Desktop"
+            $userProfileDesktop = Join-Path -Path $currentUserProfile -ChildPath 'Desktop'
             do {
                   $outputFileName = "payload_$i.xml"
-                  if (Test-Path $userProfileDesktop\$outputFileName) {
+                  $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                  if (Test-Path $payloadFile) {
                         $i++
                         Write-Verbose "$i"
                   }
-            } until (!(Test-Path $userProfileDesktop\$outputFileName))
-            if (!(Test-Path $userProfileDesktop\$outputFileName)) {
+            } until (!(Test-Path $payloadFile))
+            if (!(Test-Path $payloadFile)) {
                   try {
-                        $outputFileName = "payload_$i.xml"
-                        $payload.Save("$userProfileDesktop\$outputFileName")
+                        $payload.Save("$payloadFile")
                         Write-Verbose "Saved payload to file, will now end!"
                         break
                   }

--- a/source/public/Import-GOAssetItem.ps1
+++ b/source/public/Import-GOAssetItem.ps1
@@ -320,21 +320,17 @@ function Import-GOAssetItem {
                         $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                         if (Test-Path $payloadFile) {
                               $i++
-                              Write-Information "$i"
+                              Write-Verbose "$i"
                         }
                   } until (!(Test-Path $payloadFile))
                   if (!(Test-Path $payloadFile)) {
                         try {
-                              $outputFileName = "payload_$i.xml"
-                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                               $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
                         }
                         catch {
-                              Write-Error "Unable to save payload to file!"
-                              Write-Error "$_"
-                              break
+                              throw $_
                         }
                   }
             }

--- a/source/public/Import-GOContactItem.ps1
+++ b/source/public/Import-GOContactItem.ps1
@@ -156,21 +156,17 @@ function Import-GOContactItem {
                         $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                         if (Test-Path $payloadFile) {
                               $i++
-                              Write-Information "$i"
+                              Write-Verbose "$i"
                         }
                   } until (!(Test-Path $payloadFile))
                   if (!(Test-Path $payloadFile)) {
                         try {
-                              $outputFileName = "payload_$i.xml"
-                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                               $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
                         }
                         catch {
-                              Write-Error "Unable to save payload to file!"
-                              Write-Error "$_"
-                              break
+                              throw $_
                         }
                   }
             }

--- a/source/public/Import-GOOrganizationItem.ps1
+++ b/source/public/Import-GOOrganizationItem.ps1
@@ -187,21 +187,17 @@ function Import-GOOrganizationItem {
                         $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                         if (Test-Path $payloadFile) {
                               $i++
-                              Write-Information "$i"
+                              Write-Verbose "$i"
                         }
                   } until (!(Test-Path $payloadFile))
                   if (!(Test-Path $payloadFile)) {
                         try {
-                              $outputFileName = "payload_$i.xml"
-                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                               $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
                         }
                         catch {
-                              Write-Error "Unable to save payload to file!"
-                              Write-Error "$_"
-                              break
+                              throw $_
                         }
                   }
             }

--- a/source/public/Import-GORequestItem.ps1
+++ b/source/public/Import-GORequestItem.ps1
@@ -225,21 +225,17 @@ function Import-GORequestItem {
                         $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                         if (Test-Path $payloadFile) {
                               $i++
-                              Write-Information "$i"
+                              Write-Verbose "$i"
                         }
                   } until (!(Test-Path $payloadFile))
                   if (!(Test-Path $payloadFile)) {
                         try {
-                              $outputFileName = "payload_$i.xml"
-                              $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
                               $payload.Save("$payloadFile")
                               Write-Verbose "Saved payload to file, will now end!"
                               break
                         }
                         catch {
-                              Write-Error "Unable to save payload to file!"
-                              Write-Error "$_"
-                              break
+                              throw $_
                         }
                   }
             }

--- a/source/public/Ping-GOWebService.ps1
+++ b/source/public/Ping-GOWebService.ps1
@@ -1,35 +1,4 @@
 function Ping-GOWebService {
-      <#
-      .SYNOPSIS
-            Ping BPS/GO web services.
-      .DESCRIPTION
-            Can be used to check if service is available and correct credentials have been provided..
-
-      .NOTES
-            Copyright 2019 Easit AB
-
-            Licensed under the Apache License, Version 2.0 (the "License");
-            you may not use this file except in compliance with the License.
-            You may obtain a copy of the License at
-
-                http://www.apache.org/licenses/LICENSE-2.0
-
-            Unless required by applicable law or agreed to in writing, software
-            distributed under the License is distributed on an "AS IS" BASIS,
-            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            See the License for the specific language governing permissions and
-            limitations under the License.
-
-      .LINK
-            https://github.com/easitab/EasitGoWebservice/blob/master/EasitGoWebservice/Ping-GOWebService.ps1
-
-      .EXAMPLE
-            Ping-GOWebService -url http://localhost/test/webservice/ -apikey 4745f62b7371c2aa5cb80be8cd56e6372f495f6g8c60494ek7f231548bb2a375
-      .PARAMETER url
-            Address to BPS/GO webservice. Default = http://localhost/webservice/
-      .PARAMETER apikey
-            API key for BPS/GO.
-      #>
       [CmdletBinding()]
       param (
             [parameter(Mandatory=$false)]
@@ -37,35 +6,74 @@ function Ping-GOWebService {
 
             [parameter(Mandatory=$true)]
             [Alias("api")]
-            [string] $apikey
+            [string] $apikey,
+
+            [parameter(Mandatory=$false)]
+            [switch] $SSO,
+
+            [parameter(Mandatory = $false)]
+            [switch] $UseBasicParsing,
+
+            [parameter(Mandatory=$false)]
+            [switch] $dryRun
       )
-
-      $payload = New-XMLforEasit -Ping
-
-      Write-Verbose "Creating header for web request.."
       try {
-            $pair = "$($apikey): "
-            $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
-            $basicAuthValue = "Basic $encodedCreds"
-            $headers = @{SOAPAction = ""; Authorization = $basicAuthValue}
-            Write-Verbose "Header created for web request."
+            $payload = New-XMLforEasit -Ping
       } catch {
-            Write-Error "Failed to create header!"
-            Write-Error "$_"
-            break
+            throw $_
       }
-      Write-Verbose "Calling web service"
+      if ($dryRun) {
+            Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it to BPS"
+            $i = 1
+            $currentUserProfile = [Environment]::GetEnvironmentVariable("USERPROFILE")
+            $userProfileDesktop = Join-Path -Path $currentUserProfile -ChildPath 'Desktop'
+            do {
+                  $outputFileName = "payload_$i.xml"
+                  $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
+                  if (Test-Path $payloadFile) {
+                        $i++
+                        Write-Verbose "$i"
+                  }
+            } until (!(Test-Path $payloadFile))
+            if (!(Test-Path $payloadFile)) {
+                  try {
+                        $payload.Save("$payloadFile")
+                        Write-Verbose "Saved payload to file, will now end!"
+                        break
+                  }
+                  catch {
+                        throw $_
+                  }
+            }
+      }
+
+      $easitWebRequestParams = @{
+            Uri = "$url"
+            Apikey = "$apikey"
+            Body = $payload
+      }
+      if ($SSO) {
+            Write-Verbose "Adding UseDefaultCredentials to param hash"
+            $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+      }
+      if ($UseBasicParsing) {
+            Write-Verbose "Adding UseBasicParsing to param hash"
+            $easitWebRequestParams.Add('UseBasicParsing',$true)
+      }
       try {
-            $r = Invoke-WebRequest -Uri $url -Method POST -ContentType 'text/xml' -Body $payload -Headers $headers
-            Write-Verbose "Successfully connected to web service"
-      } catch {
-            Write-Error "Failed to connect to BPS!"
-            Write-Error "$_"
-            return $payload
+            Write-Verbose "Calling Invoke-EasitWebRequest"
+            $r = Invoke-EasitWebRequest @easitWebRequestParams
       }
-      Write-Verbose 'Successfully connected to and recieved data from web service'
-      [xml]$functionout = $r.Content
-      Write-Verbose 'Casted content of reponse as [xml]$functionout'
-      Write-Verbose 'Returning $functionout.Envelope.Body.PingResponse.Message (Pong!)'
-      return $functionout.Envelope.Body.PingResponse.Message
+      catch {
+            throw $_
+      }
+      try {
+            Write-Verbose "Converting response"
+            $returnObject = Convert-EasitXMLToPsObject -Response $r
+      }
+      catch {
+            throw $_
+      }
+      Write-Verbose "Returning converted response"
+      return $returnObject
 }


### PR DESCRIPTION
Implemented Invoke-EasitWebRequest to Ping-GOWebService.
Added parameter 'UseBasicParsing', 'SSO' and 'dryRun'.
- UseBasicParsing: This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.
- SSO: Used if system is using SSO with IWA (Active Directory). Not needed when using SSO with SAML2.<br>
Cmdlet will use the credentials of the current user to send the web request.
- dryRun: If specified, payload will be save as payload_1.xml (or next available number) to your desktop instead of sent to Easit BPS / Easit GO.
This parameter does not append, rewrite or remove any files from your desktop.