### PR TITLE
Disabled progress bar in Invoke-EasitWebRequest

### DIFF
--- a/source/private/Invoke-EasitWebRequest.ps1
+++ b/source/private/Invoke-EasitWebRequest.ps1
@@ -19,6 +19,7 @@ function Invoke-EasitWebRequest {
 
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) initialized"
+        $ProgressPreference = 'SilentlyContinue'
     }
 
     process {
@@ -69,6 +70,7 @@ function Invoke-EasitWebRequest {
         return $returnObject
     }
     end {
+        $ProgressPreference = 'Continue'
         Write-Verbose "$($MyInvocation.MyCommand) completed"
     }
 }


### PR DESCRIPTION
Added $ProgressPreference = 'SilentlyContinue' in begin block and $ProgressPreference = 'Continue' in end block. This should improve speed of the web request done by Invoke-WebRequest.