### PR TITLE
Fixed enumeration problem while converting response from XML

### DIFF
--- a/source/private/Convert-EasitXMLToPsObject.ps1
+++ b/source/private/Convert-EasitXMLToPsObject.ps1
@@ -13,49 +13,54 @@ function Convert-EasitXMLToPsObject {
     }
 
     process {
-        $returnItem = New-Object PSObject
         if ($Response.Envelope.Body.GetItemsResponse) {
             Write-Verbose "XML contains GetItemsResponse"
-            $returnItem | Add-Member -MemberType Noteproperty -Name "requestedPage" -Value "$($Response.Envelope.Body.GetItemsResponse.requestedPage)"
-            $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfPages" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfPages)"
-            $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfItems" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfItems)"
-            foreach ($column in $Response.Envelope.Body.GetItemsResponse.Columns.GetEnumerator()) {
-                Write-Verbose "Adding property $($column.InnerText) as Noteproperty to object"
-                try {
-                    $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
-                } catch [System.InvalidOperationException] {
-                    Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
-                }
-            }
-            foreach ($item in $Response.Envelope.Body.GetItemsResponse.Items.GetEnumerator()) {
-                foreach ($itemProperty in $item.GetEnumerator()) {
-                    $itemPropertyName = "$($itemProperty.Name)"
-                    Write-Verbose "itemPropertyName = $itemPropertyName"
-                    $itemPropertyValue = "$($itemProperty.InnerText)"
-                    Write-Verbose "itemPropertyValue = $itemPropertyValue"
-                    Write-Verbose "Setting $itemPropertyName to $itemPropertyValue"
-                    $returnItem."$itemPropertyName" = "$itemPropertyValue"
-                    if ("$($itemProperty.InnerText)" -match ' \/ ') {
-                        Write-Verbose "$($itemProperty.InnerText) -match '/'"
-                        $tempPropertyValues = @()
-                        $tempPropertyValues = $itemProperty.InnerText -split ' / '
-                        Write-Verbose "tempPropertyValue with slashes = $tempPropertyValues"
-                        $count = 1
-                        foreach ($tempPropertyValue in $tempPropertyValues) {
-                            Write-Verbose "${propertyName}_${count} = $tempPropertyValue"
-                            if ("$($itemProperty.rawValue)" -notmatch 'null') {
-                                Write-Verbose "Adding ${itemPropertyName}_${count} with value $tempPropertyValue"
-                                $returnItem | Add-Member -MemberType Noteproperty -Name "${itemPropertyName}_${count}" -Value "$tempPropertyValue"
-                            }
-                            $count++
+            if ($Response.Envelope.Body.GetItemsResponse.Items) {
+                foreach ($item in $Response.Envelope.Body.GetItemsResponse.Items.GetEnumerator()) {
+                    $returnItem = New-Object PSObject
+                    $returnItem | Add-Member -MemberType Noteproperty -Name "requestedPage" -Value "$($Response.Envelope.Body.GetItemsResponse.requestedPage)"
+                    $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfPages" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfPages)"
+                    $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfItems" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfItems)"
+                    foreach ($column in $Response.Envelope.Body.GetItemsResponse.Columns.GetEnumerator()) {
+                        Write-Verbose "Adding property $($column.InnerText) as Noteproperty to object"
+                        try {
+                            $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
+                        } catch [System.InvalidOperationException] {
+                            Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
                         }
-                        $returnItem."$itemPropertyName" = "customArrayList"
                     }
+                    foreach ($itemProperty in $item.GetEnumerator()) {
+                        $itemPropertyName = "$($itemProperty.Name)"
+                        Write-Verbose "itemPropertyName = $itemPropertyName"
+                        $itemPropertyValue = "$($itemProperty.InnerText)"
+                        Write-Verbose "itemPropertyValue = $itemPropertyValue"
+                        Write-Verbose "Setting $itemPropertyName to $itemPropertyValue"
+                        $returnItem."$itemPropertyName" = "$itemPropertyValue"
+                        if ("$($itemProperty.InnerText)" -match ' \/ ') {
+                            Write-Verbose "$($itemProperty.InnerText) -match '/'"
+                            $tempPropertyValues = @()
+                            $tempPropertyValues = $itemProperty.InnerText -split ' / '
+                            Write-Verbose "tempPropertyValue with slashes = $tempPropertyValues"
+                            $count = 1
+                            foreach ($tempPropertyValue in $tempPropertyValues) {
+                                Write-Verbose "${propertyName}_${count} = $tempPropertyValue"
+                                if ("$($itemProperty.rawValue)" -notmatch 'null') {
+                                    Write-Verbose "Adding ${itemPropertyName}_${count} with value $tempPropertyValue"
+                                    $returnItem | Add-Member -MemberType Noteproperty -Name "${itemPropertyName}_${count}" -Value "$tempPropertyValue"
+                                }
+                                $count++
+                            }
+                            $returnItem."$itemPropertyName" = "customArrayList"
+                        }
+                    }
+                    $returnItem
                 }
-                $returnItem
+            } else {
+                Write-Warning "View did not return any items or objects"
             }
         } elseif ($Response.Envelope.Body.ImportItemsResponse) {
             Write-Verbose "XML contains ImportItemsResponse"
+            $returnItem = New-Object PSObject
             $importItemResult = "$($Response.Envelope.Body.ImportItemsResponse.ImportItemResult.result)"
             $returnItem | Add-Member -MemberType Noteproperty -Name "ImportItemResult" -Value "$importItemResult"
             foreach ($returnValue in $Response.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues.GetEnumerator()) {
@@ -66,11 +71,13 @@ function Convert-EasitXMLToPsObject {
             $returnItem
         } elseif ($Response.Envelope.Body.PingResponse) {
             Write-Verbose "XML contains PingResponse"
+            $returnItem = New-Object PSObject
             foreach ($pingProperty in $Response.Envelope.Body.PingResponse.GetEnumerator()) {
                 $returnItem | Add-Member -MemberType Noteproperty -Name "$($pingProperty.name)" -Value "$($pingProperty.InnerText)"
             }
             $returnItem
         } else {
+            Write-Warning "Response do not contain GetItemsResponse, ImportItemsResponse or PingResponse"
             throw "Do not know what to do with XML.."
         }
     }


### PR DESCRIPTION
When running Get-GOItems the helper function Convert-EasitXMLToPsObject is called. While looping throu the items for a "GetItemsResponse" one items data where written to all items returned from function resulting in the correct amount of items but wrong data.

Also added check so that an view with no items would not result with an error thrown.