### PR TITLE
ColumnFilter with whitespace no longer generates error

### DIFF
--- a/source/private/Export-PayloadToFile.ps1
+++ b/source/private/Export-PayloadToFile.ps1
@@ -21,7 +21,7 @@ function Export-PayloadToFile {
             $payloadFile = Join-Path -Path $userProfileDesktop -ChildPath "$outputFileName"
             if (Test-Path $payloadFile) {
                     $i++
-                    Write-Verbose "$i"
+                    Write-Verbose "$payloadFile already exists"
             }
         } until (!(Test-Path $payloadFile))
         if (!(Test-Path $payloadFile)) {

--- a/source/private/New-XMLforEasit.ps1
+++ b/source/private/New-XMLforEasit.ps1
@@ -199,7 +199,8 @@ function New-XMLforEasit {
         ## Solution provided by Dennis Zakariasson <dennis.zakariasson@regionuppsala.se> thru issue 5
         if ($ColumnFilter) {
             Write-Verbose "Creating xml element for Column filter"
-            $Filters = $ColumnFilter -split ' '
+            Write-Verbose "ColumnFilter = $ColumnFilter"
+            $Filters = $ColumnFilter -replace '; ', ';' -split ';'
             Write-Verbose "Filters = $Filters"
             Write-Verbose "Number of filters = $($Filters.Count)"
             foreach ($filter in $Filters) {

--- a/source/public/Get-GOItems.ps1
+++ b/source/public/Get-GOItems.ps1
@@ -105,9 +105,12 @@ function Get-GOItems {
             Write-Verbose "Validating column filter.."
             Write-Verbose "ColumnFilter = $ColumnFilter"
             Write-Verbose "ColumnFilters = $($ColumnFilter.Count)"
+            $filterCounter = 1
+            $numberOfFilters = $ColumnFilter.Count
+            $checkedColumnFilter = @()
             foreach ($filter in $ColumnFilter) {
                   try {
-                        Write-Verbose $filter
+                        Write-Verbose "Testing filter: $filter"
                         $FilterValues = $filter -replace ', ', ',' -split ','
                         Test-ColumnFilter -Filter $filter -FilterValues $FilterValues
                   }
@@ -116,8 +119,14 @@ function Get-GOItems {
                         Write-Error "$_"
                         return
                   }
+                  if ($filterCounter -lt $numberOfFilters) {
+                        $checkedColumnFilter += "$filter;"
+                  } else {
+                        $checkedColumnFilter += "$filter"
+                  }
+                  $filterCounter++
             }
-            $xmlParams.Add('ColumnFilter',"$ColumnFilter")
+            $xmlParams.Add('ColumnFilter',"$checkedColumnFilter")
       }
       else {
             Write-Verbose "Skipping ColumnFilter as it is null!"
@@ -131,7 +140,7 @@ function Get-GOItems {
             throw $_
       }
       if ($dryRun) {
-            Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it to BPS"
+            Write-Verbose "dryRun specified! Trying to save payload to file instead of sending it"
             try {
                   Export-PayloadToFile -Payload $payload
             } catch {


### PR DESCRIPTION
When using _-ColumnFilter_ with _Get-GOItems_ and either fieldname or value contained a whitespace the resulting payload was incorrect.

```powershell
Get-GOItems -view 'Requests' -ColumnFilter 'fieldname,EQUALS,value withwhitespace'
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:sch="http://www.easit.com/bps/schemas" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
  <soapenv:Header />
  <soapenv:Body>
    <sch:GetItemsRequest>
      <sch:ItemViewIdentifier>Requests</sch:ItemViewIdentifier>
      <sch:Page>1</sch:Page>
      <sch:SortColumn order="Descending">Id</sch:SortColumn>
      <sch:ColumnFilter columnName="fieldname" comparator="EQUALS">value</sch:ColumnFilter>
      <sch:ColumnFilter columnName="withwhitespace"></sch:ColumnFilter>
    </sch:GetItemsRequest>
  </soapenv:Body>
</soapenv:Envelope>
```