### PR TITLE
Parameter CustomProperties includes hashtable values when generating payload.

### DIFF
--- a/source/public/Import-GOCustomItem.ps1
+++ b/source/public/Import-GOCustomItem.ps1
@@ -82,10 +82,8 @@ function Import-GOCustomItem {
         $params = [ordered]@{}
         foreach ($property in $CustomProperties.GetEnumerator()) {
             try {
-                $propertyName = $property.Key
-                $propertyValue = $parDetails.Value
-                Write-Verbose "Adding $propertyName with the value $propertyValue"
-                $params.Add("$propertyName", "$propertyValue")
+                Write-Verbose "Adding $($property.Key) with the value $($property.Value)"
+                $params.Add("$($property.Key)", "$($property.Value)")
             } catch {
                 throw $_
             }


### PR DESCRIPTION
When using parameter CustomProperties in Import-GoCustomItem the values from the hashtable was not included resulting in an incorrect payload with blank text values for each property.