### PR TITLE
Convert-EasitXMLToPsObject no longer return error if ImportItemsResponse does not have ReturnValue

### DIFF
--- a/source/private/Convert-EasitXMLToPsObject.ps1
+++ b/source/private/Convert-EasitXMLToPsObject.ps1
@@ -13,72 +13,88 @@ function Convert-EasitXMLToPsObject {
     }
 
     process {
-        if ($Response.Envelope.Body.GetItemsResponse) {
-            Write-Verbose "XML contains GetItemsResponse"
-            if ($Response.Envelope.Body.GetItemsResponse.Items) {
-                foreach ($item in $Response.Envelope.Body.GetItemsResponse.Items.GetEnumerator()) {
-                    $returnItem = New-Object PSObject
-                    $returnItem | Add-Member -MemberType Noteproperty -Name "requestedPage" -Value "$($Response.Envelope.Body.GetItemsResponse.requestedPage)"
-                    $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfPages" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfPages)"
-                    $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfItems" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfItems)"
-                    foreach ($column in $Response.Envelope.Body.GetItemsResponse.Columns.GetEnumerator()) {
-                        Write-Verbose "Adding property $($column.InnerText) as Noteproperty to object"
-                        try {
-                            $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
-                        } catch [System.InvalidOperationException] {
-                            Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
-                        }
-                    }
-                    foreach ($itemProperty in $item.GetEnumerator()) {
-                        $itemPropertyName = "$($itemProperty.Name)"
-                        Write-Verbose "itemPropertyName = $itemPropertyName"
-                        $itemPropertyValue = "$($itemProperty.InnerText)"
-                        Write-Verbose "itemPropertyValue = $itemPropertyValue"
-                        Write-Verbose "Setting $itemPropertyName to $itemPropertyValue"
-                        $returnItem."$itemPropertyName" = "$itemPropertyValue"
-                        if ("$($itemProperty.InnerText)" -match ' \/ ') {
-                            Write-Verbose "$($itemProperty.InnerText) -match '/'"
-                            $tempPropertyValues = @()
-                            $tempPropertyValues = $itemProperty.InnerText -split ' / '
-                            Write-Verbose "tempPropertyValue with slashes = $tempPropertyValues"
-                            $count = 1
-                            foreach ($tempPropertyValue in $tempPropertyValues) {
-                                Write-Verbose "${propertyName}_${count} = $tempPropertyValue"
-                                if ("$($itemProperty.rawValue)" -notmatch 'null') {
-                                    Write-Verbose "Adding ${itemPropertyName}_${count} with value $tempPropertyValue"
-                                    $returnItem | Add-Member -MemberType Noteproperty -Name "${itemPropertyName}_${count}" -Value "$tempPropertyValue"
-                                }
-                                $count++
+        if ($Response.Envelope.Body.Fault) {
+            throw "$($Response.Envelope.Body.Fault.faultstring)"
+        } else {
+            if ($Response.Envelope.Body.GetItemsResponse) {
+                Write-Verbose "XML contains GetItemsResponse"
+                if ($Response.Envelope.Body.GetItemsResponse.Items) {
+                    foreach ($item in $Response.Envelope.Body.GetItemsResponse.Items.GetEnumerator()) {
+                        $returnItem = New-Object PSObject
+                        $returnItem | Add-Member -MemberType Noteproperty -Name "requestedPage" -Value "$($Response.Envelope.Body.GetItemsResponse.requestedPage)"
+                        $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfPages" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfPages)"
+                        $returnItem | Add-Member -MemberType Noteproperty -Name "totalNumberOfItems" -Value "$($Response.Envelope.Body.GetItemsResponse.totalNumberOfItems)"
+                        $returnItem | Add-Member -MemberType Noteproperty -Name "databaseId" -Value "$($item.id)"
+                        foreach ($column in $Response.Envelope.Body.GetItemsResponse.Columns.GetEnumerator()) {
+                            Write-Verbose "Adding property $($column.InnerText) as Noteproperty to object"
+                            try {
+                                $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
+                            } catch [System.InvalidOperationException] {
+                                Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
                             }
-                            $returnItem."$itemPropertyName" = "customArrayList"
                         }
+                        foreach ($itemProperty in $item.GetEnumerator()) {
+                            $itemPropertyName = "$($itemProperty.Name)"
+                            Write-Verbose "itemPropertyName = $itemPropertyName"
+                            $itemPropertyValue = "$($itemProperty.InnerText)"
+                            Write-Verbose "itemPropertyValue = $itemPropertyValue"
+                            Write-Verbose "Setting $itemPropertyName to $itemPropertyValue"
+                            $returnItem."$itemPropertyName" = "$itemPropertyValue"
+                            if ("$($itemProperty.InnerText)" -match ' \/ ') {
+                                Write-Verbose "$($itemProperty.InnerText) -match '/'"
+                                $tempPropertyValues = @()
+                                $tempPropertyValues = $itemProperty.InnerText -split ' / '
+                                Write-Verbose "tempPropertyValue with slashes = $tempPropertyValues"
+                                $count = 1
+                                foreach ($tempPropertyValue in $tempPropertyValues) {
+                                    Write-Verbose "${propertyName}_${count} = $tempPropertyValue"
+                                    if ("$($itemProperty.rawValue)" -notmatch 'null') {
+                                        Write-Verbose "Adding ${itemPropertyName}_${count} with value $tempPropertyValue"
+                                        $returnItem | Add-Member -MemberType Noteproperty -Name "${itemPropertyName}_${count}" -Value "$tempPropertyValue"
+                                    }
+                                    $count++
+                                }
+                                $returnItem."$itemPropertyName" = "customArrayList"
+                            }
+                        }
+                        $returnItem
+                    }
+                } else {
+                    Write-Warning "View did not return any items or objects"
+                }
+            } elseif ($Response.Envelope.Body.ImportItemsResponse) {
+                Write-Verbose "XML contains ImportItemsResponse"
+                $returnItem = New-Object PSObject
+                $importItemResult = "$($Response.Envelope.Body.ImportItemsResponse.ImportItemResult.result)"
+                Write-Verbose "importItemResult = $importItemResult"
+                if ($importItemResult -ne 'OK') {
+                    Write-Verbose "An exception was returned from the webservice"
+                    throw "$($Response.Envelope.Body.ImportItemsResponse.ImportItemResult.SkippedOrExceptionMessage)"
+                } else {
+                    $returnItem | Add-Member -MemberType Noteproperty -Name "ImportItemResult" -Value "$importItemResult"
+                    if ($Response.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues) {
+                        foreach ($returnValue in $Response.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues.GetEnumerator()) {
+                            Write-Verbose "Name = $($returnValue.name)"
+                            Write-Verbose "Value = $($returnValue.InnerText)"
+                            $returnItem | Add-Member -MemberType Noteproperty -Name "$($returnValue.name)" -Value "$($returnValue.InnerText)"
+                        }
+                    } else {
+                        Write-Verbose "Response does not contain any return values"
+                        $returnItem | Add-Member -MemberType Noteproperty -Name "ReturnValues" -Value "None"
                     }
                     $returnItem
                 }
+            } elseif ($Response.Envelope.Body.PingResponse) {
+                Write-Verbose "XML contains PingResponse"
+                $returnItem = New-Object PSObject
+                foreach ($pingProperty in $Response.Envelope.Body.PingResponse.GetEnumerator()) {
+                    $returnItem | Add-Member -MemberType Noteproperty -Name "$($pingProperty.name)" -Value "$($pingProperty.InnerText)"
+                }
+                $returnItem
             } else {
-                Write-Warning "View did not return any items or objects"
+                Write-Warning "Response do not contain GetItemsResponse, ImportItemsResponse or PingResponse"
+                throw "Do not know what to do with XML.."
             }
-        } elseif ($Response.Envelope.Body.ImportItemsResponse) {
-            Write-Verbose "XML contains ImportItemsResponse"
-            $returnItem = New-Object PSObject
-            $importItemResult = "$($Response.Envelope.Body.ImportItemsResponse.ImportItemResult.result)"
-            $returnItem | Add-Member -MemberType Noteproperty -Name "ImportItemResult" -Value "$importItemResult"
-            foreach ($returnValue in $Response.Envelope.Body.ImportItemsResponse.ImportItemResult.ReturnValues.GetEnumerator()) {
-                Write-Verbose "Name = $($returnValue.name)"
-                Write-Verbose "Value = $($returnValue.InnerText)"
-                $returnItem | Add-Member -MemberType Noteproperty -Name "$($returnValue.name)" -Value "$($returnValue.InnerText)"
-            }
-            $returnItem
-        } elseif ($Response.Envelope.Body.PingResponse) {
-            Write-Verbose "XML contains PingResponse"
-            $returnItem = New-Object PSObject
-            foreach ($pingProperty in $Response.Envelope.Body.PingResponse.GetEnumerator()) {
-                $returnItem | Add-Member -MemberType Noteproperty -Name "$($pingProperty.name)" -Value "$($pingProperty.InnerText)"
-            }
-            $returnItem
-        } else {
-            Write-Warning "Response do not contain GetItemsResponse, ImportItemsResponse or PingResponse"
-            throw "Do not know what to do with XML.."
         }
     }
 

--- a/source/private/Invoke-EasitWebRequest.ps1
+++ b/source/private/Invoke-EasitWebRequest.ps1
@@ -59,11 +59,12 @@ function Invoke-EasitWebRequest {
             ($requestResponse = Invoke-WebRequest @webRequestParams -ErrorAction Stop).BaseResponse
             Write-Verbose "Successfully connected to and imported data"
         } catch [System.Net.WebException] {
-            Write-Verbose "StatusCode = $($_.Exception.Response.StatusDescription)"
-            if ($_.Exception.Response.StatusDescription -eq 404) {
+            $statusCode = $_.Exception.Response.StatusCode.value__
+            Write-Verbose "StatusCode = $statusCode"
+            if ($statusCode -eq 404) {
                 $dets = "url"
             }
-            if ($_.Exception.Response.StatusDescription -eq 500) {
+            if ($statusCode -eq 500) {
                 $dets = "apikey, ImportHandlerIdentifier/importViewIdentifier and properties for the items/object in payload"
                 $addHelp = "You can try running $((Get-Variable MyInvocation -Scope 1).Value.MyCommand.Name) with -dryRun to save payload to your desktop (${HOME}\Desktop\payload_x.xml)."
             }


### PR DESCRIPTION
If an endpoint for import does not return any step/steps the XML-element ReturnValues is missing from the response. No check for the presens of this element was done before, now we do.