### PR TITLE
Changed implementation of -dryRun

### DIFF
--- a/source/public/Get-GOItems.ps1
+++ b/source/public/Get-GOItems.ps1
@@ -146,35 +146,33 @@ function Get-GOItems {
             } catch {
                   throw $_
             }
-            break
+      } else {
+            $easitWebRequestParams = @{
+                  Uri = "$url"
+                  Apikey = "$apikey"
+                  Body = $payload
+            }
+            if ($SSO) {
+                  Write-Verbose "Adding UseDefaultCredentials to param hash"
+                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+            }
+            if ($UseBasicParsing) {
+                  Write-Verbose "Adding UseBasicParsing to param hash"
+                  $easitWebRequestParams.Add('UseBasicParsing',$true)
+            }
+            try {
+                  Write-Verbose "Calling Invoke-EasitWebRequest"
+                  $r = Invoke-EasitWebRequest @easitWebRequestParams
+            } catch {
+                  throw $_
+            }
+            try {
+                  Write-Verbose "Converting response"
+                  $returnObject = Convert-EasitXMLToPsObject -Response $r
+            } catch {
+                  throw $_
+            }
+            Write-Verbose "Returning converted response"
+            $returnObject
       }
-      $easitWebRequestParams = @{
-            Uri = "$url"
-            Apikey = "$apikey"
-            Body = $payload
-      }
-      if ($SSO) {
-            Write-Verbose "Adding UseDefaultCredentials to param hash"
-            $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-      }
-      if ($UseBasicParsing) {
-            Write-Verbose "Adding UseBasicParsing to param hash"
-            $easitWebRequestParams.Add('UseBasicParsing',$true)
-      }
-      try {
-            Write-Verbose "Calling Invoke-EasitWebRequest"
-            $r = Invoke-EasitWebRequest @easitWebRequestParams
-      }
-      catch {
-            throw $_
-      }
-      try {
-            Write-Verbose "Converting response"
-            $returnObject = Convert-EasitXMLToPsObject -Response $r
-      }
-      catch {
-            throw $_
-      }
-      Write-Verbose "Returning converted response"
-      $returnObject
 }

--- a/source/public/Import-GOAssetItem.ps1
+++ b/source/public/Import-GOAssetItem.ps1
@@ -361,37 +361,35 @@ function Import-GOAssetItem {
                   } catch {
                         throw $_
                   }
-                  break
+            } else {
+                  $easitWebRequestParams = @{
+                        Uri = "$url"
+                        Apikey = "$apikey"
+                        Body = $payload
+                  }
+                  if ($SSO) {
+                        Write-Verbose "Adding UseDefaultCredentials to param hash"
+                        $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+                  }
+                  if ($UseBasicParsing) {
+                        Write-Verbose "Adding UseBasicParsing to param hash"
+                        $easitWebRequestParams.Add('UseBasicParsing',$true)
+                  }
+                  try {
+                        Write-Verbose "Calling Invoke-EasitWebRequest"
+                        $r = Invoke-EasitWebRequest @easitWebRequestParams
+                  } catch {
+                        throw $_
+                  }
+                  try {
+                        Write-Verbose "Converting response"
+                        $returnObject = Convert-EasitXMLToPsObject -Response $r
+                  } catch {
+                        throw $_
+                  }
+                  Write-Verbose "Returning converted response"
+                  return $returnObject
             }
-            $easitWebRequestParams = @{
-                  Uri = "$url"
-                  Apikey = "$apikey"
-                  Body = $payload
-            }
-            if ($SSO) {
-                  Write-Verbose "Adding UseDefaultCredentials to param hash"
-                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-            }
-            if ($UseBasicParsing) {
-                  Write-Verbose "Adding UseBasicParsing to param hash"
-                  $easitWebRequestParams.Add('UseBasicParsing',$true)
-            }
-            try {
-                  Write-Verbose "Calling Invoke-EasitWebRequest"
-                  $r = Invoke-EasitWebRequest @easitWebRequestParams
-            }
-            catch {
-                  throw $_
-            }
-            try {
-                  Write-Verbose "Converting response"
-                  $returnObject = Convert-EasitXMLToPsObject -Response $r
-            }
-            catch {
-                  throw $_
-            }
-            Write-Verbose "Returning converted response"
-            return $returnObject
       }
 
       end {

--- a/source/public/Import-GOContactItem.ps1
+++ b/source/public/Import-GOContactItem.ps1
@@ -197,37 +197,35 @@ function Import-GOContactItem {
                   } catch {
                         throw $_
                   }
-                  break
+            } else {
+                  $easitWebRequestParams = @{
+                        Uri = "$url"
+                        Apikey = "$apikey"
+                        Body = $payload
+                  }
+                  if ($SSO) {
+                        Write-Verbose "Adding UseDefaultCredentials to param hash"
+                        $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+                  }
+                  if ($UseBasicParsing) {
+                        Write-Verbose "Adding UseBasicParsing to param hash"
+                        $easitWebRequestParams.Add('UseBasicParsing',$true)
+                  }
+                  try {
+                        Write-Verbose "Calling Invoke-EasitWebRequest"
+                        $r = Invoke-EasitWebRequest @easitWebRequestParams
+                  } catch {
+                        throw $_
+                  }
+                  try {
+                        Write-Verbose "Converting response"
+                        $returnObject = Convert-EasitXMLToPsObject -Response $r
+                  } catch {
+                        throw $_
+                  }
+                  Write-Verbose "Returning converted response"
+                  return $returnObject
             }
-            $easitWebRequestParams = @{
-                  Uri = "$url"
-                  Apikey = "$apikey"
-                  Body = $payload
-            }
-            if ($SSO) {
-                  Write-Verbose "Adding UseDefaultCredentials to param hash"
-                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-            }
-            if ($UseBasicParsing) {
-                  Write-Verbose "Adding UseBasicParsing to param hash"
-                  $easitWebRequestParams.Add('UseBasicParsing',$true)
-            }
-            try {
-                  Write-Verbose "Calling Invoke-EasitWebRequest"
-                  $r = Invoke-EasitWebRequest @easitWebRequestParams
-            }
-            catch {
-                  throw $_
-            }
-            try {
-                  Write-Verbose "Converting response"
-                  $returnObject = Convert-EasitXMLToPsObject -Response $r
-            }
-            catch {
-                  throw $_
-            }
-            Write-Verbose "Returning converted response"
-            return $returnObject
       }
       end {
             Write-Verbose "$($MyInvocation.MyCommand) completed"

--- a/source/public/Import-GOCustomItem.ps1
+++ b/source/public/Import-GOCustomItem.ps1
@@ -102,37 +102,35 @@ function Import-GOCustomItem {
 			} catch {
 				throw $_
 			}
-			break
-		}
-        $easitWebRequestParams = @{
+		} else {
+            $easitWebRequestParams = @{
                 Uri = "$url"
                 Apikey = "$apikey"
                 Body = $payload
+            }
+            if ($SSO) {
+                    Write-Verbose "Adding UseDefaultCredentials to param hash"
+                    $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+            }
+            if ($UseBasicParsing) {
+                    Write-Verbose "Adding UseBasicParsing to param hash"
+                    $easitWebRequestParams.Add('UseBasicParsing',$true)
+            }
+            try {
+                    Write-Verbose "Calling Invoke-EasitWebRequest"
+                    $r = Invoke-EasitWebRequest @easitWebRequestParams
+            } catch {
+                    throw $_
+            }
+            try {
+                    Write-Verbose "Converting response"
+                    $returnObject = Convert-EasitXMLToPsObject -Response $r
+            } catch {
+                    throw $_
+            }
+            Write-Verbose "Returning converted response"
+            return $returnObject
         }
-        if ($SSO) {
-                Write-Verbose "Adding UseDefaultCredentials to param hash"
-                $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-        }
-        if ($UseBasicParsing) {
-                Write-Verbose "Adding UseBasicParsing to param hash"
-                $easitWebRequestParams.Add('UseBasicParsing',$true)
-        }
-        try {
-                Write-Verbose "Calling Invoke-EasitWebRequest"
-                $r = Invoke-EasitWebRequest @easitWebRequestParams
-        }
-        catch {
-                throw $_
-        }
-        try {
-                Write-Verbose "Converting response"
-                $returnObject = Convert-EasitXMLToPsObject -Response $r
-        }
-        catch {
-                throw $_
-        }
-        Write-Verbose "Returning converted response"
-        return $returnObject
     }
 
     end {

--- a/source/public/Import-GOOrganizationItem.ps1
+++ b/source/public/Import-GOOrganizationItem.ps1
@@ -228,37 +228,35 @@ function Import-GOOrganizationItem {
                   } catch {
                         throw $_
                   }
-                  break
+            } else {
+                  $easitWebRequestParams = @{
+                        Uri = "$url"
+                        Apikey = "$apikey"
+                        Body = $payload
+                  }
+                  if ($SSO) {
+                        Write-Verbose "Adding UseDefaultCredentials to param hash"
+                        $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+                  }
+                  if ($UseBasicParsing) {
+                        Write-Verbose "Adding UseBasicParsing to param hash"
+                        $easitWebRequestParams.Add('UseBasicParsing',$true)
+                  }
+                  try {
+                        Write-Verbose "Calling Invoke-EasitWebRequest"
+                        $r = Invoke-EasitWebRequest @easitWebRequestParams
+                  } catch {
+                        throw $_
+                  }
+                  try {
+                        Write-Verbose "Converting response"
+                        $returnObject = Convert-EasitXMLToPsObject -Response $r
+                  } catch {
+                        throw $_
+                  }
+                  Write-Verbose "Returning converted response"
+                  return $returnObject
             }
-            $easitWebRequestParams = @{
-                  Uri = "$url"
-                  Apikey = "$apikey"
-                  Body = $payload
-            }
-            if ($SSO) {
-                  Write-Verbose "Adding UseDefaultCredentials to param hash"
-                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-            }
-            if ($UseBasicParsing) {
-                  Write-Verbose "Adding UseBasicParsing to param hash"
-                  $easitWebRequestParams.Add('UseBasicParsing',$true)
-            }
-            try {
-                  Write-Verbose "Calling Invoke-EasitWebRequest"
-                  $r = Invoke-EasitWebRequest @easitWebRequestParams
-            }
-            catch {
-                  throw $_
-            }
-            try {
-                  Write-Verbose "Converting response"
-                  $returnObject = Convert-EasitXMLToPsObject -Response $r
-            }
-            catch {
-                  throw $_
-            }
-            Write-Verbose "Returning converted response"
-            return $returnObject
       }
       end {
             Write-Verbose "$($MyInvocation.MyCommand) completed"

--- a/source/public/Import-GORequestItem.ps1
+++ b/source/public/Import-GORequestItem.ps1
@@ -266,37 +266,35 @@ function Import-GORequestItem {
 			} catch {
 				throw $_
 			}
-			break
-		}
-            $easitWebRequestParams = @{
-                  Uri = "$url"
-                  Apikey = "$apikey"
-                  Body = $payload
+		} else {
+                  $easitWebRequestParams = @{
+                        Uri = "$url"
+                        Apikey = "$apikey"
+                        Body = $payload
+                  }
+                  if ($SSO) {
+                        Write-Verbose "Adding UseDefaultCredentials to param hash"
+                        $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+                  }
+                  if ($UseBasicParsing) {
+                        Write-Verbose "Adding UseBasicParsing to param hash"
+                        $easitWebRequestParams.Add('UseBasicParsing',$true)
+                  }
+                  try {
+                        Write-Verbose "Calling Invoke-EasitWebRequest"
+                        $r = Invoke-EasitWebRequest @easitWebRequestParams
+                  } catch {
+                        throw $_
+                  }
+                  try {
+                        Write-Verbose "Converting response"
+                        $returnObject = Convert-EasitXMLToPsObject -Response $r
+                  } catch {
+                        throw $_
+                  }
+                  Write-Verbose "Returning converted response"
+                  return $returnObject
             }
-            if ($SSO) {
-                  Write-Verbose "Adding UseDefaultCredentials to param hash"
-                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-            }
-            if ($UseBasicParsing) {
-                  Write-Verbose "Adding UseBasicParsing to param hash"
-                  $easitWebRequestParams.Add('UseBasicParsing',$true)
-            }
-            try {
-                  Write-Verbose "Calling Invoke-EasitWebRequest"
-                  $r = Invoke-EasitWebRequest @easitWebRequestParams
-            }
-            catch {
-                  throw $_
-            }
-            try {
-                  Write-Verbose "Converting response"
-                  $returnObject = Convert-EasitXMLToPsObject -Response $r
-            }
-            catch {
-                  throw $_
-            }
-            Write-Verbose "Returning converted response"
-            return $returnObject
       }
       end {
             Write-Verbose "$($MyInvocation.MyCommand) completed"

--- a/source/public/Ping-GOWebService.ps1
+++ b/source/public/Ping-GOWebService.ps1
@@ -70,35 +70,33 @@ function Ping-GOWebService {
             } catch {
                   throw $_
             }
-            break
+      } else {
+            $easitWebRequestParams = @{
+                  Uri = "$url"
+                  Apikey = "$apikey"
+                  Body = $payload
+            }
+            if ($SSO) {
+                  Write-Verbose "Adding UseDefaultCredentials to param hash"
+                  $easitWebRequestParams.Add('UseDefaultCredentials',$true)
+            }
+            if ($UseBasicParsing) {
+                  Write-Verbose "Adding UseBasicParsing to param hash"
+                  $easitWebRequestParams.Add('UseBasicParsing',$true)
+            }
+            try {
+                  Write-Verbose "Calling Invoke-EasitWebRequest"
+                  $r = Invoke-EasitWebRequest @easitWebRequestParams
+            } catch {
+                  throw $_
+            }
+            try {
+                  Write-Verbose "Converting response"
+                  $returnObject = Convert-EasitXMLToPsObject -Response $r
+            } catch {
+                  throw $_
+            }
+            Write-Verbose "Returning converted response"
+            return $returnObject
       }
-      $easitWebRequestParams = @{
-            Uri = "$url"
-            Apikey = "$apikey"
-            Body = $payload
-      }
-      if ($SSO) {
-            Write-Verbose "Adding UseDefaultCredentials to param hash"
-            $easitWebRequestParams.Add('UseDefaultCredentials',$true)
-      }
-      if ($UseBasicParsing) {
-            Write-Verbose "Adding UseBasicParsing to param hash"
-            $easitWebRequestParams.Add('UseBasicParsing',$true)
-      }
-      try {
-            Write-Verbose "Calling Invoke-EasitWebRequest"
-            $r = Invoke-EasitWebRequest @easitWebRequestParams
-      }
-      catch {
-            throw $_
-      }
-      try {
-            Write-Verbose "Converting response"
-            $returnObject = Convert-EasitXMLToPsObject -Response $r
-      }
-      catch {
-            throw $_
-      }
-      Write-Verbose "Returning converted response"
-      return $returnObject
 }


### PR DESCRIPTION
When running any public cmdlet with -dryRun the cmdlet would 'break' after saving payload to file, effectively preventing any sort of loop to use cmdlet with -dryRun.

```powershell
foreach ($item in $items) {
    Import-GOContactItem -ID $item.id -Phone $item.phone -dryRun
}
```
In the example above the first $item in $items would have its payload saved to file and then the cmdlet would break.
With the changes in this PR all $item in $items will have its payload saved to file.