### PR TITLE
Remove default value for -sortField and -sortOrder in Get-GOItems

### DIFF
--- a/source/private/New-XMLforEasit.ps1
+++ b/source/private/New-XMLforEasit.ps1
@@ -16,10 +16,10 @@ function New-XMLforEasit {
         [Parameter(Mandatory=$false, ParameterSetName="get")]
         [int] $Page = 1,
 
-        [Parameter(Mandatory=$true, ParameterSetName="get")]
+        [Parameter(Mandatory=$false, ParameterSetName="get")]
         [string] $SortField,
 
-        [Parameter(Mandatory=$true, ParameterSetName="get")]
+        [Parameter(Mandatory=$false, ParameterSetName="get")]
         [string] $SortOrder,
 
         [Parameter(Mandatory=$false, ParameterSetName="get")]
@@ -184,17 +184,24 @@ function New-XMLforEasit {
             Write-Error "$_"
             break
         }
-
-        try {
-            Write-Verbose "Creating xml element for SortColumn order"
-            $envelopeSortColumnOrder = $payload.CreateElement('sch:SortColumn',"$xmlnsSch")
-            $envelopeSortColumnOrder.SetAttribute("order","$SortOrder")
-            $envelopeSortColumnOrder.InnerText  = "$SortField"
-            $schGetItemsRequest.AppendChild($envelopeSortColumnOrder) | Out-Null
-        } catch {
-            Write-Error "Failed to create xml element for Page"
-            Write-Error "$_"
-            break
+        if (!([string]::IsNullOrWhiteSpace($sortOrder))) {
+            if ([string]::IsNullOrWhiteSpace($sortField)) {
+                  Write-Warning "Please provide a sortField when using sortOrder"
+                  break
+            }
+            if (!([string]::IsNullOrWhiteSpace($sortField))) {
+                try {
+                    Write-Verbose "Creating xml element for SortColumn order"
+                    $envelopeSortColumnOrder = $payload.CreateElement('sch:SortColumn',"$xmlnsSch")
+                    $envelopeSortColumnOrder.SetAttribute("order","$SortOrder")
+                    $envelopeSortColumnOrder.InnerText  = "$SortField"
+                    $schGetItemsRequest.AppendChild($envelopeSortColumnOrder) | Out-Null
+                } catch {
+                    Write-Error "Failed to create xml element for Page"
+                    Write-Error "$_"
+                    break
+                }
+            }
         }
         ## Solution provided by Dennis Zakariasson <dennis.zakariasson@regionuppsala.se> thru issue 5
         if ($ColumnFilter) {

--- a/source/public/Get-GOItems.ps1
+++ b/source/public/Get-GOItems.ps1
@@ -17,11 +17,11 @@ function Get-GOItems {
 
             [parameter(Mandatory = $false)]
             [Alias("so")]
-            [string] $sortOrder = "Descending",
+            [string] $sortOrder,
 
             [parameter(Mandatory = $false)]
             [Alias("sf")]
-            [string] $sortField = "Id",
+            [string] $sortField,
 
             [parameter(Mandatory = $false)]
             [Alias("page")]
@@ -97,9 +97,17 @@ function Get-GOItems {
       $xmlParams = @{
             Get = $true
             ItemViewIdentifier = "$importViewIdentifier"
-            SortOrder = "$sortOrder"
-            SortField = "$sortField"
             Page = "$viewPageNumber"
+      }
+      if (!([string]::IsNullOrWhiteSpace($sortOrder))) {
+            $xmlParams.Add('SortOrder',"$sortOrder")
+            if ([string]::IsNullOrWhiteSpace($sortField)) {
+                  Write-Warning "Please provide a sortField when using sortOrder"
+                  break
+            }
+      }
+      if (!([string]::IsNullOrWhiteSpace($sortField))) {
+            $xmlParams.Add('SortField',"$sortField")
       }
       if ($ColumnFilter) {
             Write-Verbose "Validating column filter.."

--- a/tests/Get-GOItems.Tests.ps1
+++ b/tests/Get-GOItems.Tests.ps1
@@ -20,10 +20,10 @@ Describe 'Get-GOItems' {
         Get-Command "$commandName" | Should -HaveParameter importViewIdentifier -Mandatory
     }
     It 'should have a parameter named sortOrder with a default value' {
-        Get-Command "$commandName" | Should -HaveParameter sortOrder -DefaultValue 'Descending'
+        Get-Command "$commandName" | Should -HaveParameter sortOrder -Not -Mandatory
     }
     It 'should have a parameter named sortField with a default value' {
-        Get-Command "$commandName" | Should -HaveParameter sortField -DefaultValue 'Id'
+        Get-Command "$commandName" | Should -HaveParameter sortField -Not -Mandatory
     }
     It 'should have a parameter named viewPageNumber with a default value' {
         Get-Command "$commandName" | Should -HaveParameter viewPageNumber -DefaultValue 1

--- a/tests/New-XMLforEasit.Tests.ps1
+++ b/tests/New-XMLforEasit.Tests.ps1
@@ -33,10 +33,10 @@ Describe "New-XMLforEasit" {
                     Get-Command "$commandName" | Should -HaveParameter ItemViewIdentifier -Mandatory
                 }
                 It 'an SortField if request is Get' {
-                    Get-Command "$commandName" | Should -HaveParameter SortField -Mandatory
+                    Get-Command "$commandName" | Should -HaveParameter SortField -Not -Mandatory
                 }
                 It 'an SortOrder if request is Get' {
-                    Get-Command "$commandName" | Should -HaveParameter SortOrder -Mandatory
+                    Get-Command "$commandName" | Should -HaveParameter SortOrder -Not -Mandatory
                 }
             }
             if ($set.Name -eq 'import') {


### PR DESCRIPTION
As not all views may include the field Id it does not make sence to have default values or have them be mandatory.
-sortField and -sortOrder in Get-GOItems is no longer mandatory and does not have default values.
SortField and SortOrder in private function New-XMLforEasit have also been changed.

Updated tests for New-XMLforEasit and Get-GOItems