### PR TITLE
Improved handling when ws does not return 200

### DIFF
--- a/source/private/Convert-EasitXMLToPsObject.ps1
+++ b/source/private/Convert-EasitXMLToPsObject.ps1
@@ -14,7 +14,7 @@ function Convert-EasitXMLToPsObject {
 
     process {
         if ($Response.Envelope.Body.Fault) {
-            throw "$($Response.Envelope.Body.Fault.faultstring)"
+            throw "$($Response.Envelope.Body.Fault.faultstring.innerText)"
         } else {
             if ($Response.Envelope.Body.GetItemsResponse) {
                 Write-Verbose "XML contains GetItemsResponse"


### PR DESCRIPTION
Invoke-EasitWebRequest now returns and displays error from Easit GO ws. If a "fault" is returned the "faultstring" will be displayed.
This is when return code is 500. In any other case the status description will be displayed.