### PR TITLE
Add support for multiple attachments

### DIFF
--- a/docs/v2/Import-GOAssetItem.md
+++ b/docs/v2/Import-GOAssetItem.md
@@ -91,6 +91,18 @@ Import-GOAssetItem @importEasitItem -ID 156 -Status 'Inactive'
 
 In this example we have a configuration file located in our users home directory with the url and apikey.
 
+### EXAMPLE 6
+
+```powershell
+Import-GOAssetItem
+    -ImportHandlerIdentifier 'CreateAssetGeneral'
+    -ID '456'
+    -Attachment 'file;C:\Path\To\Attachment.docx','base64;filename.txt;base64stringofattachment'
+```
+
+In this example we have a configuration file located in our users home directory with the url and apikey.\
+We are updating an asset with ID 456 with 2 attachments.
+
 ## PARAMETERS
 
 ### -ActivityDebit

--- a/docs/v2/Import-GOContactItem.md
+++ b/docs/v2/Import-GOContactItem.md
@@ -81,6 +81,18 @@ Import-GOContactItem @importEasitItem -ID 156 -Inactive 'false' -Responsible_Man
 
 In this example we have a configuration file located in our users home directory with the url and apikey.
 
+### EXAMPLE 6
+
+```powershell
+Import-GOContactItem
+    -ImportHandlerIdentifier 'CreateContact'
+    -ID '456'
+    -Attachment 'file;C:\Path\To\Attachment.docx','base64;filename.txt;base64stringofattachment'
+```
+
+In this example we have a configuration file located in our users home directory with the url and apikey.\
+We are updating an contact with ID 456 with 2 attachments.
+
 ## PARAMETERS
 
 ### -apikey

--- a/docs/v2/Import-GOOrganizationItem.md
+++ b/docs/v2/Import-GOOrganizationItem.md
@@ -92,6 +92,18 @@ Import-GOOrganizationItem @importEasitItem -Status 'Inactive'
 
 In this example we have a configuration file located in our users home directory with the url and apikey.
 
+### EXAMPLE 6
+
+```powershell
+Import-GOOrganizationItem
+    -ImportHandlerIdentifier 'CreateOrganizationSupplier'
+    -ID '456'
+    -Attachment 'file;C:\Path\To\Attachment.docx','base64;filename.txt;base64stringofattachment'
+```
+
+In this example we have a configuration file located in our users home directory with the url and apikey.\
+We are updating an supplier with ID 456 with 2 attachments.
+
 ## PARAMETERS
 
 ### -AccountManager

--- a/docs/v2/Import-GORequestItem.md
+++ b/docs/v2/Import-GORequestItem.md
@@ -85,6 +85,18 @@ $importEasitItem = @{
 Import-GORequestItem @importEasitItem -Description 'Updating description for request 156'
 ```
 
+### EXAMPLE 6
+
+```powershell
+Import-GORequestItem
+    -ImportHandlerIdentifier 'CreateRequest'
+    -ID '456'
+    -Attachment 'file;C:\Path\To\Attachment.docx','base64;filename.txt;base64stringofattachment'
+```
+
+In this example we have a configuration file located in our users home directory with the url and apikey.\
+We are updating an request with ID 456 with 2 attachments.
+
 ## PARAMETERS
 
 ### -apikey

--- a/source/private/Set-Attachment.ps1
+++ b/source/private/Set-Attachment.ps1
@@ -1,0 +1,62 @@
+function Set-Attachment {
+    [CmdletBinding(HelpURI="https://github.com/easitab/EasitGoWebservice/blob/main/docs/v2/Set-Attachment.md")]
+    param (
+        [Parameter(Mandatory)]
+        [string]$InputObject
+    )
+    
+    begin {
+        Write-Verbose "$($MyInvocation.MyCommand) initialized"
+    }
+    
+    process {
+        $attachmentDetails = $InputObject -split ';'
+        $attachmentType = $attachmentDetails[0].Trim()
+        Write-Verbose "attachmentType = $attachmentType"
+        if (!($attachmentType -like 'file') -and !($attachmentType -like 'base64')) {
+            throw "Unknown type of attachment"
+        }
+        $returnObject = New-Object PSObject
+        if ($attachmentType -like 'file') {
+            $attachment = $attachmentDetails[-1].Trim()
+            $returnObject | Add-Member -MemberType Noteproperty -Name "attachmentType" -Value "file"
+            $separator = "\"
+            $fileNametoHeader = $attachment.Split($separator)
+            $attachmentName = $fileNametoHeader[-1]
+            try {
+                $base64string = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("$attachment"))
+                Write-Verbose "Converted file to base64"
+            } catch {
+                throw $_
+            }
+        }
+        if ($attachmentType -like 'base64') {
+            if ($attachmentDetails.Count -ne 3) {
+                throw "Invalid syntax for attachment, please use type;filename;base64string"
+            }
+            $returnObject | Add-Member -MemberType Noteproperty -Name "attachmentType" -Value "base64"
+            $attachmentName = $attachmentDetails[1].Trim()
+            $base64string = $attachmentDetails[-1].Trim()
+        }
+        
+        if ([string]::IsNullOrEmpty($attachmentName)) {
+            Write-Verbose "attachmentName IsNullOrEmpty, setting value to 'null'"
+            $attachmentName = 'null'
+        } else {
+            Write-Verbose "attachmentName = $attachmentName"
+        }
+        $returnObject | Add-Member -MemberType Noteproperty -Name "attachmentName" -Value "$attachmentName"
+        if ([string]::IsNullOrEmpty($base64string)) {
+            Write-Verbose "base64string IsNullOrEmpty, setting value to 'null'"
+            $base64string = 'null'
+        } else {
+            Write-Verbose "base64string is not NullOrEmpty"
+        }
+        $returnObject | Add-Member -MemberType Noteproperty -Name "attachment" -Value "$base64string"
+        return $returnObject
+    }
+    
+    end {
+        Write-Verbose "$($MyInvocation.MyCommand) completed"
+    }
+}

--- a/source/public/Import-GOAssetItem.ps1
+++ b/source/public/Import-GOAssetItem.ps1
@@ -265,7 +265,7 @@ function Import-GOAssetItem {
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
             [Alias("File")]
-            [string] $Attachment,
+            [string[]] $Attachment,
 
             [parameter(Mandatory = $false)]
             [switch] $SSO,
@@ -335,7 +335,7 @@ function Import-GOAssetItem {
                         Write-Verbose "$($parameter.Name) is part of BPS parameter set"
                         $parDetails = Get-Variable -Name $parameter.Name
                         if ($parDetails.Value) {
-                              Write-Verbose "$($parameter.Name) have a value"
+                              Write-Verbose "$($parameter.Name) have a value, $($parDetails.Value)"
                               $parName = $parDetails.Name
                               $parValue = $parDetails.Value
                               $params.Add("$parName", "$parValue")

--- a/source/public/Import-GOContactItem.ps1
+++ b/source/public/Import-GOContactItem.ps1
@@ -100,7 +100,7 @@ function Import-GOContactItem {
 
             [parameter(ParameterSetName = 'BPSAttribute', ValueFromPipelineByPropertyName = $true)]
             [Alias("File")]
-            [string] $Attachment,
+            [string[]] $Attachment,
 
             [parameter(Mandatory = $false)]
             [switch] $SSO,
@@ -171,7 +171,7 @@ function Import-GOContactItem {
                         Write-Verbose "$($parameter.Name) is part of BPS parameter set"
                         $parDetails = Get-Variable -Name $parameter.Name
                         if ($parDetails.Value) {
-                              Write-Verbose "$($parameter.Name) have a value"
+                              Write-Verbose "$($parameter.Name) have a value, $($parDetails.Value)"
                               $parName = $parDetails.Name
                               $parValue = $parDetails.Value
                               $params.Add("$parName", "$parValue")

--- a/source/public/Import-GOCustomItem.ps1
+++ b/source/public/Import-GOCustomItem.ps1
@@ -83,14 +83,14 @@ function Import-GOCustomItem {
         foreach ($property in $CustomProperties.GetEnumerator()) {
             try {
                 Write-Verbose "Adding $($property.Key) with the value $($property.Value)"
-		if($property.Value.Count -gt 1){
+                if($property.Value.Count -gt 1){
                     $params.$($property.Key) = @()
                     foreach($p in $property.Value){
                         $params.$($property.Key) += "$($p)"
                     }
                 } else {
-			$params.Add("$($property.Key)", "$($property.Value)")
-		}
+                    $params.Add("$($property.Key)", "$($property.Value)")
+                }
             } catch {
                 throw $_
             }

--- a/source/public/Import-GOOrganizationItem.ps1
+++ b/source/public/Import-GOOrganizationItem.ps1
@@ -135,7 +135,7 @@ function Import-GOOrganizationItem {
 
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [Alias("File")]
-            [string] $Attachment,
+            [string[]] $Attachment,
 
             [parameter(Mandatory=$false)]
             [switch] $SSO,
@@ -204,7 +204,7 @@ function Import-GOOrganizationItem {
                         Write-Verbose "$($parameter.Name) is part of BPS parameter set!"
                         $parDetails = Get-Variable -Name $parameter.Name
                         if ($parDetails.Value) {
-                              Write-Verbose "$($parameter.Name) have a value"
+                              Write-Verbose "$($parameter.Name) have a value, $($parDetails.Value)"
                               $parName = $parDetails.Name
                               $parValue = $parDetails.Value
                               $params.Add("$parName", "$parValue")

--- a/source/public/Import-GORequestItem.ps1
+++ b/source/public/Import-GORequestItem.ps1
@@ -173,7 +173,7 @@ function Import-GORequestItem {
 
             [parameter(ParameterSetName='BPSAttribute',ValueFromPipelineByPropertyName=$true)]
             [Alias("File")]
-            [string] $Attachment,
+            [string[]] $Attachment,
 
             [parameter(Mandatory=$false)]
             [switch] $SSO,
@@ -242,7 +242,7 @@ function Import-GORequestItem {
                         Write-Verbose "$($parameter.Name) is part of BPS parameter set"
                         $parDetails = Get-Variable -Name $parameter.Name
                         if ($parDetails.Value) {
-                              Write-Verbose "$($parameter.Name) have a value"
+                              Write-Verbose "$($parameter.Name) have a value, $($parDetails.Value)"
                               $parName = $parDetails.Name
                               $parValue = $parDetails.Value
                               $params.Add("$parName", "$parValue")


### PR DESCRIPTION
This PR enhances the functionality of the parameter Attachment for all of the "Import-GO*" funtions to accept multiple attachments.

Ex:
-Attachment "type;value","type;value"
-Attachment "file;C:\example.txt","base64;stringcontainingfileinbase64"