### PR TITLE
Add support for collections

### DIFF
--- a/source/private/Convert-EasitXMLToPsObject.ps1
+++ b/source/private/Convert-EasitXMLToPsObject.ps1
@@ -29,10 +29,19 @@ function Convert-EasitXMLToPsObject {
                         $returnItem | Add-Member -MemberType Noteproperty -Name "databaseId" -Value "$($item.id)"
                         foreach ($column in $Response.Envelope.Body.GetItemsResponse.Columns.GetEnumerator()) {
                             Write-Verbose "Adding property $($column.InnerText) as Noteproperty to object"
-                            try {
-                                $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
-                            } catch [System.InvalidOperationException] {
-                                Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
+                            if ($column.Collection -eq 'true') {
+                                try {
+                                    $array = @()
+                                    $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $array -ErrorAction 'Stop'
+                                } catch {
+                                    Write-Warning "$($_.Exception.Message)"
+                                }
+                            } else {
+                                try {
+                                    $returnItem | Add-Member -MemberType Noteproperty -Name "$($column.InnerText)" -Value $null -ErrorAction 'Stop'
+                                } catch [System.InvalidOperationException] {
+                                    Write-Warning "$($column.InnerText) is used two times in the importViewIdentifier specified, this could be due to duplicates of the same field or that two fields have the same name. The value from the latest occurance will be used!"
+                                }
                             }
                         }
                         foreach ($itemProperty in $item.GetEnumerator()) {
@@ -41,14 +50,23 @@ function Convert-EasitXMLToPsObject {
                             $itemPropertyValue = "$($itemProperty.InnerText)"
                             Write-Verbose "itemPropertyValue = $itemPropertyValue"
                             Write-Verbose "Setting $itemPropertyName to $itemPropertyValue"
-                            $returnItem."$itemPropertyName" = "$itemPropertyValue"
-                            if (!([string]::IsNullOrEmpty("$($itemProperty.rawValue)"))) {
-                                $itemPropertyrawValue = "$($itemProperty.rawValue)"
-                                $itemPropertyrawValueName = "${itemPropertyName}_rawValue"
-                                Write-Verbose "itemPropertyrawValueName = $itemPropertyrawValueName"
-                                Write-Verbose "itemPropertyrawValue = $itemPropertyrawValue"
-                                $returnItem | Add-Member -MemberType Noteproperty -Name "${itemPropertyName}_rawValue" -Value "$itemPropertyrawValue"
+                            if ($returnItem."$itemPropertyName" -is 'System.Array') {
+                                $propHash = @{
+                                    Value = "$itemPropertyValue"
+                                    rawValue = "$($itemProperty.rawValue)"
+                                }
+                                $returnItem."$itemPropertyName" += $propHash
+                            } else {
+                                $returnItem."$itemPropertyName" = "$itemPropertyValue"
+                                if (!([string]::IsNullOrEmpty("$($itemProperty.rawValue)"))) {
+                                    $itemPropertyrawValue = "$($itemProperty.rawValue)"
+                                    $itemPropertyrawValueName = "${itemPropertyName}_rawValue"
+                                    Write-Verbose "itemPropertyrawValueName = $itemPropertyrawValueName"
+                                    Write-Verbose "itemPropertyrawValue = $itemPropertyrawValue"
+                                    $returnItem | Add-Member -MemberType Noteproperty -Name "${itemPropertyName}_rawValue" -Value "$itemPropertyrawValue"
+                                }
                             }
+                            
                             <#
                             if ("$($itemProperty.InnerText)" -match ' \/ ') {
                                 Write-Verbose "$($itemProperty.InnerText) -match '/'"


### PR DESCRIPTION
This change adds support for collections by checking if the column attribute 'collection' is true in GetItemsResponse.
Get-GOItems will then return each property for the collection as a hashtable containing 'Value' and 'rawValue'.